### PR TITLE
docs: bootstrap-generated planning docs and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,129 @@
+# CLAUDE.md — agentic-workflow
+
+> Portable Claude Code workflow toolkit: custom skills, config archive, repo bootstrapper, and a bidirectional MCP bridge for multi-agent communication.
+
+## Required Context
+
+Read before making changes:
+
+| Document | Purpose |
+|----------|---------|
+| `planning/ARCHITECTURE.md` | System components and data flow |
+| `planning/API_CONTRACT.md` | MCP bridge REST & tool schemas |
+| `planning/CODE_STYLE.md` | TypeScript conventions and patterns |
+| `planning/TESTING.md` | Test strategy and coverage targets |
+| `planning/ERD.md` | SQLite schema and relationships |
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|------------|
+| Runtime | Node.js >= 20, ES2022 target |
+| Language | TypeScript 5.7, strict mode |
+| HTTP | Fastify 5 |
+| Database | SQLite via better-sqlite3, WAL mode |
+| MCP | @modelcontextprotocol/sdk (stdio transport) |
+| Validation | Zod 3 |
+| Test | Vitest (in-memory SQLite) |
+| Build | tsc (ESM, Node16 module resolution) |
+
+## Architecture
+
+```
+agentic-workflow/
+├── skills/                    # Claude Code custom skills (symlinked to ~/.claude/skills/)
+│   ├── review/                # Multi-agent PR review orchestrator
+│   ├── postReview/            # GitHub comment publisher
+│   ├── addressReview/         # Review fix implementer
+│   └── enhancePrompt/         # Context-aware prompt rewriter
+├── bootstrap/                 # Repo documentation generator skill
+├── config/                    # Settings & MCP config archive
+├── mcp-bridge/                # MCP bridge application
+│   └── src/
+│       ├── application/       # AppResult<T> pattern, service functions (never throw)
+│       │   ├── result.ts      # ok<T>(), err<T>(), AppError, AppResult<T>
+│       │   └── services/      # Business logic — pure functions taking DbClient
+│       ├── db/                # SQLite schema, client interface, transactions
+│       │   ├── schema.ts      # MIGRATIONS constant, createDatabase()
+│       │   └── client.ts      # DbClient interface (prepared statements, no SQL injection)
+│       ├── transport/         # Typed router, Zod schemas, controllers
+│       │   ├── types.ts       # RouteSchema, defineRoute<TSchema>()
+│       │   └── schemas/       # Zod schemas for messages and tasks
+│       ├── routes/            # Route factories (wire schemas → handlers)
+│       ├── server.ts          # Fastify server factory
+│       ├── mcp.ts             # MCP stdio server (5 tools)
+│       └── index.ts           # REST API entry point
+├── planning/                  # Generated project documentation
+└── setup.sh                   # One-command setup script
+```
+
+## Key Patterns
+
+### AppResult\<T\> — Services never throw
+
+```typescript
+import { ok, err, type AppResult } from "./application/result.js";
+
+function myService(db: DbClient, input: Input): AppResult<Output> {
+  if (invalid) return err({ code: "VALIDATION", message: "...", statusHint: 400 });
+  return ok(result);
+}
+```
+
+### Typed Router — Compile-time schema ↔ handler linking
+
+```typescript
+import { defineRoute, type RouteSchema } from "./transport/types.js";
+
+const MySchema = { body: z.object({...}), response: z.object({...}) } satisfies RouteSchema;
+export const myRoute = defineRoute<typeof MySchema>({ method: "POST", url: "/path", schema: MySchema, handler: ... });
+```
+
+### Transactions — Atomic multi-step operations
+
+```typescript
+const result = db.transaction(() => {
+  db.insertMessage(msg);
+  db.updateTaskStatus(taskId, status);
+  return { message: msg, task_updated: true };
+});
+```
+
+## Code Style
+
+- **ESM only** — all imports use `.js` extensions
+- **No classes** — factory functions and closures
+- **No exceptions in business logic** — AppResult everywhere
+- **Zod for all external input** — request bodies, env vars, MCP tool args
+- **Prepared statements only** — never interpolate SQL
+
+## Commands
+
+```bash
+# MCP Bridge
+cd mcp-bridge
+npm run build          # TypeScript → dist/
+npm run dev            # Dev server with tsx
+npm start              # Production server (Fastify on :3100)
+npm test               # Vitest (all tests, in-memory SQLite)
+npm run test:watch     # Vitest watch mode
+npm run typecheck      # tsc --noEmit
+
+# Setup (from repo root)
+./setup.sh             # Symlink skills, copy config, install deps
+```
+
+## Merge Gate
+
+Before merging any PR:
+1. `npm run typecheck` passes with zero errors
+2. `npm test` passes with all tests green
+3. No `any` types outside of Fastify integration boundaries
+
+## Commit Conventions
+
+Format: `type: short description`
+
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+
+Keep commits atomic — one logical change per commit. See `planning/COMMIT_STRATEGY.md` for details.

--- a/planning/API_CONTRACT.md
+++ b/planning/API_CONTRACT.md
@@ -1,0 +1,509 @@
+# API Contract -- MCP Bridge
+
+All REST endpoints return a standard envelope:
+
+```jsonc
+// Success
+{ "ok": true, "data": <response> }
+
+// Error
+{ "ok": false, "error": { "code": "<CODE>", "message": "<human-readable>", "details": <optional> } }
+```
+
+POST endpoints return **201** on success. GET endpoints return **200** on success.
+
+---
+
+## GET /health
+
+Health check endpoint. Registered directly on the Fastify instance.
+
+### Request
+
+No parameters, no body.
+
+### Response (200)
+
+```json
+{ "status": "ok" }
+```
+
+**Note:** This endpoint does NOT use the standard `{ ok, data }` envelope -- it returns the object directly.
+
+### Error Cases
+
+| HTTP Status | Code | Meaning |
+|---|---|---|
+| 500 | `INTERNAL_ERROR` | Server failed to respond |
+
+### Side Effects
+
+None.
+
+---
+
+## POST /messages/send
+
+Send context from one agent to another. The message is persisted and queued for pickup.
+
+### Request
+
+**Body** (JSON):
+
+| Field | Type | Required | Validation | Description |
+|---|---|---|---|---|
+| `conversation` | string | Yes | UUID format | Conversation thread identifier |
+| `sender` | string | Yes | min length 1 | Sending agent identifier |
+| `recipient` | string | Yes | min length 1 | Receiving agent identifier |
+| `payload` | string | Yes | min length 1 | Message content to send |
+| `meta_prompt` | string | No | -- | Optional guidance for the recipient on how to process this context |
+
+### Response (201)
+
+```jsonc
+{
+  "ok": true,
+  "data": {
+    "id": "uuid",              // Generated message ID
+    "conversation": "uuid",
+    "sender": "string",
+    "recipient": "string",
+    "kind": "context",         // Always "context" for this endpoint
+    "payload": "string",
+    "meta_prompt": "string|null",
+    "created_at": "ISO-8601",
+    "read_at": null             // Always null on creation
+  }
+}
+```
+
+### Error Cases
+
+| HTTP Status | Code | Meaning |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | Request body failed Zod validation (missing/invalid fields). `details` contains the Zod issue array. |
+| 500 | `INTERNAL_ERROR` | Unexpected server error |
+
+### Side Effects
+
+- Inserts one row into the `messages` table with `kind = 'context'`.
+
+---
+
+## GET /messages/conversation/:conversation
+
+Retrieve all messages for a conversation in chronological order.
+
+### Request
+
+**Path Parameters:**
+
+| Param | Type | Required | Validation | Description |
+|---|---|---|---|---|
+| `conversation` | string | Yes | UUID format | Conversation thread identifier |
+
+### Response (200)
+
+```jsonc
+{
+  "ok": true,
+  "data": [
+    {
+      "id": "uuid",
+      "conversation": "uuid",
+      "sender": "string",
+      "recipient": "string",
+      "kind": "context|task|status|reply",
+      "payload": "string",
+      "meta_prompt": "string|null",
+      "created_at": "ISO-8601",
+      "read_at": "ISO-8601|null"
+    }
+    // ... ordered by created_at ASC
+  ]
+}
+```
+
+Returns an empty array if no messages exist for the conversation.
+
+### Error Cases
+
+| HTTP Status | Code | Meaning |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | Path parameter `conversation` is not a valid UUID |
+| 500 | `INTERNAL_ERROR` | Unexpected server error |
+
+### Side Effects
+
+None. Read-only.
+
+---
+
+## GET /messages/unread
+
+Get unread messages for a specific recipient. Messages are marked as read atomically on retrieval.
+
+### Request
+
+**Query Parameters:**
+
+| Param | Type | Required | Validation | Description |
+|---|---|---|---|---|
+| `recipient` | string | Yes | min length 1 | Agent identifier to check for unread messages |
+
+### Response (200)
+
+```jsonc
+{
+  "ok": true,
+  "data": [
+    {
+      "id": "uuid",
+      "conversation": "uuid",
+      "sender": "string",
+      "recipient": "string",
+      "kind": "context|task|status|reply",
+      "payload": "string",
+      "meta_prompt": "string|null",
+      "created_at": "ISO-8601",
+      "read_at": null              // Always null in the returned snapshot
+    }
+    // ... ordered by created_at ASC
+  ]
+}
+```
+
+Returns an empty array if no unread messages exist.
+
+### Error Cases
+
+| HTTP Status | Code | Meaning |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | Query parameter `recipient` is missing or empty |
+| 500 | `INTERNAL_ERROR` | Unexpected server error |
+
+### Side Effects
+
+- **Marks all returned messages as read** by setting `read_at` to the current timestamp. This happens atomically in a SQLite transaction: the unread messages are fetched, then all messages for that recipient with `read_at IS NULL` are bulk-updated.
+- Subsequent calls with the same recipient will not return previously fetched messages.
+
+---
+
+## POST /tasks/assign
+
+Assign a task with domain classification and implementation details. Creates both a task record and a conversation message atomically.
+
+### Request
+
+**Body** (JSON):
+
+| Field | Type | Required | Validation | Description |
+|---|---|---|---|---|
+| `conversation` | string | Yes | UUID format | Conversation thread this task belongs to |
+| `domain` | string | Yes | min length 1 | Task domain (e.g. `"frontend"`, `"backend"`, `"security"`) |
+| `summary` | string | Yes | min length 1 | Brief task summary |
+| `details` | string | Yes | min length 1 | Detailed implementation instructions |
+| `analysis` | string | No | -- | Analysis or research request to accompany the task |
+| `assigned_to` | string | No | -- | Agent identifier to assign the task to |
+
+### Response (201)
+
+```jsonc
+{
+  "ok": true,
+  "data": {
+    "id": "uuid",               // Generated task ID
+    "conversation": "uuid",
+    "domain": "string",
+    "summary": "string",
+    "details": "string",
+    "analysis": "string|null",
+    "assigned_to": "string|null",
+    "status": "pending",        // Always "pending" on creation
+    "created_at": "ISO-8601",
+    "updated_at": "ISO-8601"
+  }
+}
+```
+
+### Error Cases
+
+| HTTP Status | Code | Meaning |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | Request body failed Zod validation |
+| 500 | `INTERNAL_ERROR` | Unexpected server error |
+
+### Side Effects
+
+- Inserts one row into the `tasks` table with `status = 'pending'`.
+- Inserts one row into the `messages` table with:
+  - `sender`: `"system"`
+  - `recipient`: value of `assigned_to`, or `"unassigned"` if omitted
+  - `kind`: `"task"`
+  - `payload`: JSON string containing `{ task_id, domain, summary, details }`
+  - `meta_prompt`: `null`
+- Both inserts are wrapped in a single SQLite transaction.
+
+---
+
+## GET /tasks/:id
+
+Get a single task by its ID.
+
+### Request
+
+**Path Parameters:**
+
+| Param | Type | Required | Validation | Description |
+|---|---|---|---|---|
+| `id` | string | Yes | UUID format | Task identifier |
+
+### Response (200)
+
+```jsonc
+{
+  "ok": true,
+  "data": {
+    "id": "uuid",
+    "conversation": "uuid",
+    "domain": "string",
+    "summary": "string",
+    "details": "string",
+    "analysis": "string|null",
+    "assigned_to": "string|null",
+    "status": "pending|in_progress|completed|failed",
+    "created_at": "ISO-8601",
+    "updated_at": "ISO-8601"
+  }
+}
+```
+
+### Error Cases
+
+| HTTP Status | Code | Meaning |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | Path parameter `id` is not a valid UUID |
+| 404 | `NOT_FOUND` | No task exists with the given ID. Message: `"Task <id> not found"` |
+| 500 | `INTERNAL_ERROR` | Unexpected server error |
+
+### Side Effects
+
+None. Read-only.
+
+---
+
+## GET /tasks/conversation/:conversation
+
+Get all tasks for a conversation in chronological order.
+
+### Request
+
+**Path Parameters:**
+
+| Param | Type | Required | Validation | Description |
+|---|---|---|---|---|
+| `conversation` | string | Yes | UUID format | Conversation thread identifier |
+
+### Response (200)
+
+```jsonc
+{
+  "ok": true,
+  "data": [
+    {
+      "id": "uuid",
+      "conversation": "uuid",
+      "domain": "string",
+      "summary": "string",
+      "details": "string",
+      "analysis": "string|null",
+      "assigned_to": "string|null",
+      "status": "pending|in_progress|completed|failed",
+      "created_at": "ISO-8601",
+      "updated_at": "ISO-8601"
+    }
+    // ... ordered by created_at ASC
+  ]
+}
+```
+
+Returns an empty array if no tasks exist for the conversation.
+
+### Error Cases
+
+| HTTP Status | Code | Meaning |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | Path parameter `conversation` is not a valid UUID |
+| 500 | `INTERNAL_ERROR` | Unexpected server error |
+
+### Side Effects
+
+None. Read-only.
+
+---
+
+## POST /tasks/report
+
+Report status back with feedback, suggestions, or completion. Optionally updates an associated task.
+
+### Request
+
+**Body** (JSON):
+
+| Field | Type | Required | Validation | Description |
+|---|---|---|---|---|
+| `conversation` | string | Yes | UUID format | Conversation thread identifier |
+| `sender` | string | Yes | min length 1 | Reporting agent identifier |
+| `recipient` | string | Yes | min length 1 | Agent to notify |
+| `task_id` | string | No | UUID format | Task ID to update status on. If provided, the task must exist. |
+| `status` | string | Yes | One of: `"in_progress"`, `"completed"`, `"failed"` | Current status to report |
+| `payload` | string | Yes | min length 1 | Status report content -- feedback, suggestions, or completion details |
+
+### Response (201)
+
+```jsonc
+{
+  "ok": true,
+  "data": {
+    "message_id": "uuid",      // ID of the created status message
+    "task_updated": true        // Whether a task was updated (true only if task_id was provided)
+  }
+}
+```
+
+### Error Cases
+
+| HTTP Status | Code | Meaning |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | Request body failed Zod validation |
+| 404 | `NOT_FOUND` | `task_id` was provided but no task exists with that ID. Message: `"Task <id> not found"` |
+| 500 | `INTERNAL_ERROR` | Unexpected server error |
+
+### Side Effects
+
+- Inserts one row into the `messages` table with:
+  - `kind`: `"status"`
+  - `meta_prompt`: `null`
+- If `task_id` is provided and the task exists:
+  - Updates the task's `status` field to the provided value
+  - Updates the task's `analysis` field to the `payload` value (only if not already set, via `COALESCE(@analysis, analysis)`)
+  - Updates the task's `updated_at` timestamp
+- The task existence check happens before any writes. The message insert and task update are wrapped in a single SQLite transaction.
+
+---
+
+## MCP Tool: send_context
+
+Identical logic to `POST /messages/send`, exposed over MCP stdio transport.
+
+### Parameters
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `conversation` | string (UUID) | Yes | Conversation UUID -- use `crypto.randomUUID()` to start a new one |
+| `sender` | string (min 1) | Yes | Sender agent identifier (e.g. `"claude-code"`, `"codex"`) |
+| `recipient` | string (min 1) | Yes | Recipient agent identifier |
+| `payload` | string (min 1) | Yes | The context or message content to send |
+| `meta_prompt` | string | No | Optional meta-prompt guiding how the recipient should process this |
+
+### Response
+
+On success, returns a JSON text block containing the full `MessageRow` object (same shape as the REST `data` field).
+
+On error, returns an error text block: `"Error [<CODE>]: <message>"` with `isError: true`.
+
+### Side Effects
+
+Same as `POST /messages/send`.
+
+---
+
+## MCP Tool: get_messages
+
+Identical logic to `GET /messages/conversation/:conversation`, exposed over MCP stdio transport.
+
+### Parameters
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `conversation` | string (UUID) | Yes | Conversation UUID to retrieve messages for |
+
+### Response
+
+On success, returns a JSON text block containing an array of `MessageRow` objects in chronological order.
+
+### Side Effects
+
+None. Read-only.
+
+---
+
+## MCP Tool: get_unread
+
+Identical logic to `GET /messages/unread`, exposed over MCP stdio transport.
+
+### Parameters
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `recipient` | string (min 1) | Yes | Agent identifier to check for unread messages |
+
+### Response
+
+On success, returns a JSON text block containing an array of unread `MessageRow` objects. Messages are marked as read atomically on retrieval.
+
+### Side Effects
+
+Same as `GET /messages/unread` -- marks all returned messages as read.
+
+---
+
+## MCP Tool: assign_task
+
+Identical logic to `POST /tasks/assign`, exposed over MCP stdio transport.
+
+### Parameters
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `conversation` | string (UUID) | Yes | Conversation UUID this task belongs to |
+| `domain` | string (min 1) | Yes | Task domain (e.g. `"frontend"`, `"backend"`, `"security"`) |
+| `summary` | string (min 1) | Yes | Brief task summary |
+| `details` | string (min 1) | Yes | Detailed implementation instructions |
+| `analysis` | string | No | Analysis or research request to accompany the task |
+| `assigned_to` | string | No | Agent identifier to assign the task to |
+
+### Response
+
+On success, returns a JSON text block containing the full `TaskRow` object.
+
+### Side Effects
+
+Same as `POST /tasks/assign` -- inserts one task row and one message row in a transaction.
+
+---
+
+## MCP Tool: report_status
+
+Identical logic to `POST /tasks/report`, exposed over MCP stdio transport.
+
+### Parameters
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `conversation` | string (UUID) | Yes | Conversation UUID |
+| `sender` | string (min 1) | Yes | Reporting agent identifier |
+| `recipient` | string (min 1) | Yes | Agent to notify |
+| `task_id` | string (UUID) | No | Task ID to update status on |
+| `status` | enum | Yes | One of: `"in_progress"`, `"completed"`, `"failed"` |
+| `payload` | string (min 1) | Yes | Status report content -- feedback, suggestions, or completion details |
+
+### Response
+
+On success, returns a JSON text block containing `{ message_id, task_updated }`.
+
+On error (task not found), returns an error text block: `"Error [NOT_FOUND]: Task <id> not found"` with `isError: true`.
+
+### Side Effects
+
+Same as `POST /tasks/report` -- inserts a status message and optionally updates the referenced task in a transaction.

--- a/planning/ARCHITECTURE.md
+++ b/planning/ARCHITECTURE.md
@@ -1,0 +1,199 @@
+# Agentic Workflow Architecture
+
+## System Overview
+
+Agentic Workflow is a portable Claude Code toolkit with three independent components: a set of custom skills for multi-agent PR review, a documentation bootstrapper skill, and a TypeScript MCP bridge server for inter-agent communication. The skills are installed by symlinking into `~/.claude/skills/` and invoked as slash commands inside Claude Code sessions. The MCP bridge runs as either a stdio MCP server (registered with `claude mcp add`) or a standalone Fastify REST API, persisting messages and tasks to a local SQLite database so agents can exchange context asynchronously.
+
+```mermaid
+graph TD
+    subgraph "Claude Code Session"
+        User --> |"/review 42"| Review[review skill]
+        User --> |"/postReview"| PostReview[postReview skill]
+        User --> |"/addressReview"| AddressReview[addressReview skill]
+        User --> |"/enhancePrompt"| EnhancePrompt[enhancePrompt skill]
+        User --> |"/bootstrap"| Bootstrap[bootstrap skill]
+    end
+
+    Review --> |"gh pr diff"| GitHub
+    Review --> |"Agent tool"| Triage[Triage Subagent]
+    Triage --> Reviewers[Parallel Reviewer Subagents]
+    Reviewers --> StateFile[".review-cache/{pr}.json"]
+
+    PostReview --> StateFile
+    PostReview --> |"gh api"| GitHub
+
+    AddressReview --> StateFile
+    AddressReview --> |"Agent tool"| ImplTriage[Address Triage Subagent]
+    ImplTriage --> Implementers[Parallel Implementer Subagents]
+    Implementers --> |"git push"| GitHub
+
+    subgraph "MCP Bridge"
+        MCP[mcp.ts — stdio] --> Services[Application Services]
+        REST[index.ts — Fastify :3100] --> Services
+        Services --> SQLite[(bridge.db)]
+    end
+
+    Review -.-> |"send_context / assign_task"| MCP
+```
+
+## Directory Tree
+
+```
+agentic-workflow/
+├── skills/                              # Claude Code custom slash-command skills
+│   ├── review/                          # /review — multi-agent PR review orchestrator
+│   │   ├── SKILL.md                     #   skill manifest + 7-step orchestration flow
+│   │   ├── triage-prompt.md             #   subagent prompt: classify files → reviewer agents
+│   │   └── reviewer-prompt.md           #   subagent prompt: domain-specific code review
+│   ├── postReview/                      # /postReview — publish findings to GitHub
+│   │   └── SKILL.md                     #   reads .review-cache, posts batched PR reviews
+│   ├── addressReview/                   # /addressReview — implement review fixes
+│   │   ├── SKILL.md                     #   orchestrator: triage → parallel implementers
+│   │   ├── address-triage-prompt.md     #   subagent prompt: group issues → impl agents
+│   │   └── implementer-prompt.md        #   subagent prompt: fix code, commit, reply
+│   └── enhancePrompt/                   # /enhancePrompt — context-aware prompt rewriter
+│       └── SKILL.md                     #   discovers docs, enriches user prompt
+├── bootstrap/                           # /bootstrap — repo documentation generator
+│   └── SKILL.md                         #   audits 17 Pivot-pattern docs, generates missing
+├── config/                              # Claude Code configuration archive
+│   ├── settings.json                    #   model, plugins, permissions, experimental flags
+│   └── mcp.json                         #   MCP server registrations (mobai)
+├── mcp-bridge/                          # TypeScript MCP bridge server
+│   ├── package.json                     #   Node >=20, Fastify 5, better-sqlite3, Zod 3
+│   ├── tsconfig.json                    #   ES2022, Node16 modules, strict mode
+│   └── src/
+│       ├── index.ts                     #   REST entry point — binds Fastify on :3100
+│       ├── mcp.ts                       #   MCP entry point — stdio transport, 5 tools
+│       ├── server.ts                    #   Fastify factory — registers routes, Zod validation
+│       ├── db/
+│       │   ├── schema.ts               #   SQLite migrations (messages + tasks tables, WAL)
+│       │   └── client.ts               #   DbClient interface — prepared statements, transactions
+│       ├── application/
+│       │   ├── result.ts               #   AppResult<T> discriminated union (ok/err, never throws)
+│       │   └── services/
+│       │       ├── send-context.ts     #   Insert a "context" message into a conversation
+│       │       ├── get-messages.ts     #   Fetch by conversation; fetch unread + mark-read (atomic)
+│       │       ├── assign-task.ts      #   Insert task + notification message (transactional)
+│       │       └── report-status.ts    #   Insert status message + update task (transactional)
+│       ├── transport/
+│       │   ├── types.ts               #   RouteSchema, ApiRequest<T>, ApiResponse<T>, defineRoute()
+│       │   ├── schemas/
+│       │   │   ├── common.ts          #   Shared Zod schemas: IdParams, ConversationParams, RecipientQuery
+│       │   │   ├── message-schemas.ts #   SendContext, GetMessages, GetUnread request/response schemas
+│       │   │   └── task-schemas.ts    #   AssignTask, GetTask, GetTasksByConversation, ReportStatus schemas
+│       │   └── controllers/
+│       │       ├── message-controller.ts  #   Delegates to message services, maps AppResult → ApiResponse
+│       │       └── task-controller.ts     #   Delegates to task services, maps AppResult → ApiResponse
+│       └── routes/
+│           ├── messages.ts            #   POST /messages/send, GET /messages/conversation/:id, GET /messages/unread
+│           └── tasks.ts               #   POST /tasks/assign, GET /tasks/:id, GET /tasks/conversation/:id, POST /tasks/report
+├── setup.sh                            # One-command installer: symlinks skills, copies config, npm install
+├── .gitignore                          # Ignores node_modules, dist, *.db, .env, .review-cache
+└── README.md                           # Project overview, setup instructions, env vars
+```
+
+## Component 1: Skills (skills/, bootstrap/)
+
+### Overview
+
+Five Claude Code custom skills defined as Markdown SKILL.md files with YAML frontmatter. Skills are slash commands that Claude Code executes as structured workflows. They use the `Agent` tool to spawn parallel subagents and `gh` CLI for GitHub API access.
+
+### Review Pipeline (skills/review/)
+
+A three-phase PR review workflow with a shared state file (`.review-cache/{number}.json`) as the coordination mechanism:
+
+**Phase 1 — `/review`:** Fetches PR diff and metadata via `gh`, spawns a triage subagent to classify changed files into domain-specific reviewer assignments (from a catalog of 12+ specialist agents like `security-sentinel`, `kieran-typescript-reviewer`, `performance-oracle`). All reviewers run in parallel via the `Agent` tool. Each returns structured JSON with severity-tagged issues (`blocking`, `issue`, `suggestion`, `nit`) including `diff_position` for inline placement. Results are written to `.review-cache/{number}.json`.
+
+**Phase 2 — `/postReview`:** Reads the state file and publishes findings to GitHub as batched PR reviews (one `gh api` call per reviewer agent). Captures posted comment IDs back into the state file. Marks `posted: true`.
+
+**Phase 3 — `/addressReview`:** Reads the state file, fetches any new human comments from GitHub since `reviewed_at`, runs an address-triage subagent to group all unresolved issues by implementation concern, then spawns parallel implementer subagents. Implementers fix code, commit, push, and reply to every comment. The state file is updated with `addressed: true` and commit SHAs. Can be re-run iteratively.
+
+### Prompt Enhancer (skills/enhancePrompt/)
+
+A utility skill that discovers project documentation files (CLAUDE.md, planning/, docs/), reads those relevant to the user's current request, and rewrites the prompt with injected context before execution. Used by `/bootstrap` as its first step.
+
+### Bootstrap (bootstrap/)
+
+Orchestrates generation of up to 17 Pivot-pattern planning documents (ARCHITECTURE, ERD, API_CONTRACT, TESTING, etc.) plus a CLAUDE.md for any repository. Audits existing coverage by searching for docs under flexible name patterns, then spawns batched `Agent` subagents (4-5 at a time) to research and write missing docs. Adapts content to the target repo's actual tech stack.
+
+## Component 2: MCP Bridge (mcp-bridge/)
+
+### Overview
+
+A TypeScript application providing two transport layers over the same business logic: a Fastify REST API (for HTTP clients) and an MCP stdio server (for Claude Code tool calls). Both transports share the same `DbClient` and application services. The bridge enables asynchronous message-passing between AI agents using a SQLite store-and-forward pattern.
+
+### Layered Architecture
+
+The bridge follows a strict three-layer architecture with unidirectional dependencies:
+
+**Transport Layer** (`transport/`, `routes/`, `server.ts`) — Handles HTTP request parsing, Zod validation, and response formatting. The `defineRoute<TSchema>()` identity function captures the generic `TSchema` type parameter, linking Zod schemas to handler signatures at compile time. The Fastify server iterates over `ControllerDefinition[]` arrays, registering each route with automatic Zod validation of `params`, `query`, and `body`. POST routes return 201; errors map `statusHint` to HTTP status codes; `ZodError` maps to 400.
+
+**Application Layer** (`application/`) — Pure functions that accept a `DbClient` and input, returning `AppResult<T>`. The `AppResult<T>` type is a discriminated union: `{ ok: true, data: T } | { ok: false, error: AppError }`. Services never throw. Multi-step operations (e.g., `assignTask` inserts both a task and a notification message) are wrapped in `db.transaction()` for atomicity.
+
+**Data Layer** (`db/`) — `schema.ts` runs DDL migrations on startup (idempotent `CREATE TABLE IF NOT EXISTS`). `client.ts` exposes a `DbClient` interface with pre-compiled prepared statements. All IDs are UUIDs generated via `crypto.randomUUID()`. The database uses WAL journal mode for concurrent read performance.
+
+### Data Model
+
+Two tables with conversation-based partitioning:
+
+**messages** — `id` (UUID PK), `conversation` (UUID), `sender`, `recipient`, `kind` (enum: context | task | status | reply), `payload` (text), `meta_prompt` (nullable), `created_at`, `read_at` (nullable, set on retrieval). Indexed on `conversation` and `(recipient, read_at)`.
+
+**tasks** — `id` (UUID PK), `conversation` (UUID), `domain`, `summary`, `details`, `analysis` (nullable), `assigned_to` (nullable), `status` (enum: pending | in_progress | completed | failed), `created_at`, `updated_at`. Indexed on `conversation` and `status`.
+
+### MCP Tools (mcp.ts)
+
+Five tools exposed over stdio transport:
+
+| Tool | Description |
+|------|-------------|
+| `send_context` | Insert a message with kind=context into a conversation |
+| `get_messages` | Retrieve full conversation history by UUID |
+| `get_unread` | Fetch unread messages for a recipient, atomically marking them read |
+| `assign_task` | Create a task + notification message in one transaction |
+| `report_status` | Send a status message and optionally update task status |
+
+### REST API (index.ts + server.ts)
+
+Seven endpoints on Fastify (default `127.0.0.1:3100`):
+
+| Method | Path | Handler |
+|--------|------|---------|
+| GET | `/health` | Health check (returns `{ status: "ok" }`) |
+| POST | `/messages/send` | `sendContext` service |
+| GET | `/messages/conversation/:conversation` | `getMessagesByConversation` service |
+| GET | `/messages/unread?recipient=` | `getUnreadMessages` service |
+| POST | `/tasks/assign` | `assignTask` service |
+| GET | `/tasks/:id` | Direct `db.getTask()` lookup |
+| GET | `/tasks/conversation/:conversation` | Direct `db.getTasksByConversation()` lookup |
+| POST | `/tasks/report` | `reportStatus` service |
+
+The server refuses to bind to non-loopback addresses unless `ALLOW_REMOTE=1` is set, since the API has no authentication.
+
+## Component 3: Config Archive (config/)
+
+Archived Claude Code configuration for replication across machines:
+
+- **settings.json** — Sets model to `opus`, enables plugins (github, superpowers, compound-engineering, swift-lsp, playwright), enables experimental agent teams flag, sets effort level to `high`.
+- **mcp.json** — Registers the `mobai` MCP server (`npx -y mobai-mcp`).
+
+## Key Rules
+
+1. **Skills are stateless Markdown.** Each skill is a SKILL.md with YAML frontmatter (`name`, `description`, `allowed-tools`, `disable-model-invocation`). The Markdown body is the prompt — Claude Code executes it step-by-step. No runtime code, no build step.
+
+2. **The review state file is the coordination contract.** `.review-cache/{number}.json` is the single source of truth shared across `/review`, `/postReview`, and `/addressReview`. All three skills read and write this file. It tracks per-issue metadata: severity, diff position, addressed status, posted comment IDs.
+
+3. **Application services never throw.** Every service function returns `AppResult<T>` — a discriminated union of `ok(data)` or `err(AppError)`. Error propagation uses value returns, not exceptions. The transport layer maps `AppError.statusHint` to HTTP status codes.
+
+4. **Type safety flows from Zod schemas through to handlers.** The `defineRoute<TSchema>()` generic captures the schema type, so `handler(req: ApiRequest<TSchema>)` gets fully inferred `params`, `query`, and `body` types. Schemas are defined once and shared between validation and type inference.
+
+5. **Multi-step writes are transactional.** `assignTask` (task + message insert) and `reportStatus` (message + task update) wrap their operations in `db.transaction()`. `getUnreadMessages` atomically fetches and marks messages read.
+
+6. **The bridge has no authentication.** The REST API binds to loopback only (`127.0.0.1`) by default and exits with an error if a non-loopback host is configured without `ALLOW_REMOTE=1`. This is a deliberate design choice for local-only multi-agent coordination.
+
+7. **Subagents run in parallel via the Agent tool.** Both `/review` (reviewer subagents) and `/addressReview` (implementer subagents) spawn all agents simultaneously in a single message. Triage always runs sequentially first to determine the agent assignments.
+
+8. **Setup is symlink-based.** `setup.sh` creates symlinks from `~/.claude/skills/` into this repo rather than copying files. Changes to skill definitions take effect immediately without re-running setup.
+
+9. **The MCP server and REST API share identical business logic.** `mcp.ts` calls the same four service functions as the Fastify controllers. The only difference is transport: stdio with `resultToContent()` formatting vs. HTTP with `ApiResponse<T>` envelopes.
+
+10. **SQLite is configured for concurrent access.** WAL journal mode is enabled on database creation, allowing multiple readers alongside a single writer — suitable for the bridge's pattern of multiple agents polling for unread messages.

--- a/planning/BUSINESS_PLAN.md
+++ b/planning/BUSINESS_PLAN.md
@@ -1,0 +1,96 @@
+# Business Plan
+
+This is a developer productivity tool, not a revenue product. This plan frames value in terms of time savings, workflow quality, and ecosystem positioning for the open-source community.
+
+## Value Proposition
+
+Agentic Workflow provides a portable, self-contained toolkit that turns Claude Code into a multi-agent development platform. It solves three problems that developers face when adopting AI-assisted coding:
+
+1. **Workflow replication is manual.** Custom skills, prompts, and configurations live in `~/.claude/` and are lost when switching machines. Agentic Workflow archives these as a Git-versioned skill library with a one-command setup script.
+
+2. **Single-agent bottlenecks.** Claude Code and Codex operate as isolated agents. There is no built-in mechanism for one agent to delegate work to another, wait for results, or maintain conversation history. The MCP bridge provides store-and-forward messaging and task assignment between any number of agents via a shared SQLite database.
+
+3. **Code review requires context switching.** Reviewing a PR means reading diffs, mentally categorizing concerns (security, performance, style), and writing comments. The `/review` skill automates this by spawning domain-specific reviewer subagents in parallel, saving structured findings to a local cache, and optionally publishing them to GitHub.
+
+## Target Users
+
+| User Profile | Use Case |
+|-------------|----------|
+| Individual developers using Claude Code | Portable skill library, bootstrapping new repos with documentation, enhanced prompts |
+| Teams running Claude Code + Codex | Multi-agent communication via MCP bridge — delegate frontend work to one agent, backend to another, coordinate results |
+| Open-source maintainers | Automated PR review pipeline — triage, parallel domain review, batch comment posting |
+| Developers setting up new projects | `/bootstrap` generates up to 17 Pivot-pattern documentation files adapted to the detected tech stack |
+
+## Cost Analysis
+
+| Component | Cost | Notes |
+|-----------|------|-------|
+| Infrastructure | $0 | Runs entirely on the developer's local machine. SQLite file-based storage, no external services. |
+| Runtime dependencies | $0 | All npm packages are open-source (MIT/ISC/Apache-2.0). |
+| Claude Code API usage | Variable | Costs are borne by the developer's existing Claude Code subscription or API quota. This tool does not add API calls beyond what the workflows themselves require. |
+| GitHub API | $0 | Uses the `gh` CLI with the developer's existing authentication. No separate API keys needed. |
+| Maintenance | Volunteer time | Open-source project — maintenance is contributor-driven. |
+
+Total recurring cost to the end user: **$0 beyond their existing Claude Code subscription.**
+
+## Time Savings Estimate
+
+These estimates are based on the workflows the toolkit automates. Actual savings depend on PR size, repo complexity, and team size.
+
+### PR Code Review (`/review` + `/postReview`)
+
+| Activity | Manual Time | Automated Time | Savings |
+|----------|-------------|----------------|---------|
+| Read diff, categorize concerns | 20-45 min | 0 min (automated triage) | 20-45 min |
+| Write inline review comments | 15-30 min | 2-3 min (review + approve/edit findings) | 13-27 min |
+| Post comments to GitHub | 5-10 min | 1 min (`/postReview`) | 4-9 min |
+| **Total per PR** | **40-85 min** | **3-4 min** | **37-81 min** |
+
+For a team reviewing 5 PRs/week, this saves approximately 3-7 hours per week.
+
+### Repo Documentation (`/bootstrap`)
+
+| Activity | Manual Time | Automated Time | Savings |
+|----------|-------------|----------------|---------|
+| Write ARCHITECTURE.md, ERD, API docs | 4-8 hours | 10-15 min | 3.75-7.75 hours |
+| Create CLAUDE.md for AI context | 30-60 min | Included in bootstrap | 30-60 min |
+| **Total per new repo** | **4.5-9 hours** | **10-15 min** | **4.25-8.75 hours** |
+
+### Multi-Agent Task Delegation (MCP Bridge)
+
+| Activity | Manual Time | Automated Time | Savings |
+|----------|-------------|----------------|---------|
+| Context switching between agent sessions | 5-10 min per handoff | 0 min (automated via send_context) | 5-10 min |
+| Re-explaining context to a second agent | 5-15 min | 0 min (meta-prompts carry context) | 5-15 min |
+| Tracking which agent is working on what | Ongoing mental overhead | Queryable via get_messages/tasks | Reduced cognitive load |
+| **Per multi-agent workflow** | **10-25 min overhead** | **< 1 min** | **~10-25 min** |
+
+### Review Fix Implementation (`/addressReview`)
+
+| Activity | Manual Time | Automated Time | Savings |
+|----------|-------------|----------------|---------|
+| Parse review comments, create TODO list | 10-20 min | 0 min (reads from .review-cache) | 10-20 min |
+| Implement fixes sequentially | Variable | Parallel agent execution | Time reduction scales with issue count |
+
+## Strategic Positioning
+
+This is **not** a product competing for market share. It is an open-source reference implementation that demonstrates:
+
+- How to build portable, version-controlled Claude Code skill libraries
+- How to use the MCP protocol for inter-agent communication
+- How to structure multi-agent workflows with store-and-forward messaging
+- How to automate code review with domain-specific subagents
+
+The project's value grows as the Claude Code and MCP ecosystems mature. Skills and bridge configurations developed here can be shared, forked, and adapted by the community.
+
+## Success Metrics
+
+Since this is not a revenue product, success is measured by utility:
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Setup friction | < 2 minutes from clone to working skills | Time `./setup.sh` from a clean machine |
+| Skill portability | Works on macOS and Linux without modification | CI testing on both platforms |
+| Bridge reliability | Zero message loss under normal operation | SQLite WAL mode + transaction guarantees |
+| Community adoption | Forks and skill contributions | GitHub metrics |
+| Documentation coverage | Bootstrap generates accurate docs for diverse tech stacks | Manual testing against varied repos |

--- a/planning/CODE_STYLE.md
+++ b/planning/CODE_STYLE.md
@@ -1,0 +1,295 @@
+# Code Style Guide
+
+This document captures the TypeScript conventions used across the `mcp-bridge` package. All new code must follow these rules.
+
+---
+
+## TypeScript Strict Mode
+
+The project compiles with `"strict": true` in `tsconfig.json`. Key compiler flags:
+
+| Flag | Value | Effect |
+|------|-------|--------|
+| `strict` | `true` | Enables all strict type-checking options |
+| `target` | `ES2022` | Top-level await, `Array.at()`, etc. |
+| `module` | `Node16` | ESM with `.js` extensions in imports |
+| `moduleResolution` | `Node16` | Node-style resolution for ESM |
+| `forceConsistentCasingInFileNames` | `true` | Prevents cross-platform casing bugs |
+| `declaration` | `true` | Generates `.d.ts` files |
+
+The `package.json` declares `"type": "module"`, so **all imports must use the `.js` extension**, even when importing `.ts` source files:
+
+```ts
+// Correct
+import { ok } from "../result.js";
+import type { DbClient } from "../../db/client.js";
+
+// Wrong - will fail at runtime
+import { ok } from "../result";
+```
+
+---
+
+## Naming Conventions
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Files and directories | `kebab-case` | `send-context.ts`, `message-controller.ts`, `message-schemas.ts` |
+| Interfaces and type aliases | `PascalCase` | `MessageRow`, `AppResult<T>`, `RouteSchema` |
+| Functions | `camelCase` | `createDbClient`, `sendContext`, `defineRoute` |
+| Constants (error code maps) | `UPPER_SNAKE_CASE` | `ERROR_CODE.notFound`, `MIGRATIONS` |
+| Zod schemas | `PascalCase` + `Schema` suffix | `SendContextBodySchema`, `MessageResponseSchema` |
+| Zod companion types | Same name as schema, without "Schema" where it refers to the inferred data type | `MessageResponse`, `SendContextBody` |
+| Route schema objects | `PascalCase` + `Schema` suffix (doubles as value and type) | `SendContextSchema` (value and type) |
+| Database row types | `PascalCase` + `Row` suffix | `MessageRow`, `TaskRow` |
+| Service input types | `PascalCase` + `Input` suffix | `SendContextInput`, `AssignTaskInput` |
+| Service result types | `PascalCase` + `Result` suffix | `ReportStatusResult` |
+
+---
+
+## Import Ordering
+
+Imports follow this order, separated by blank lines where it aids readability:
+
+1. **Type-only imports** (`import type`) from external packages
+2. **Type-only imports** from internal modules
+3. **Value imports** from external packages
+4. **Value imports** from internal modules
+
+```ts
+import type { z, ZodType } from "zod";
+
+import type { DbClient, MessageRow } from "../../db/client.js";
+import type { AppResult } from "../result.js";
+import { ok, err, ERROR_CODE } from "../result.js";
+```
+
+Use `import type` wherever possible. If a symbol is used only in type position, always import it with `import type`.
+
+---
+
+## The `AppResult` Pattern
+
+**Services never throw.** Every service function returns `AppResult<T>` -- a discriminated union:
+
+```ts
+export type AppResult<T> = { ok: true; data: T } | { ok: false; error: AppError };
+
+export interface AppError {
+  code: string;
+  message: string;
+  statusHint?: number;
+  details?: unknown;
+}
+```
+
+Use the `ok()` and `err()` helpers from `application/result.ts`:
+
+```ts
+import { ok, err, ERROR_CODE } from "../result.js";
+
+// Returning success
+return ok(row);
+
+// Returning a typed error
+return err({
+  code: ERROR_CODE.notFound,
+  message: `Task ${id} not found`,
+  statusHint: 404,
+});
+```
+
+Standard error codes are defined in `ERROR_CODE`:
+
+| Constant | Value | Typical HTTP hint |
+|----------|-------|-------------------|
+| `ERROR_CODE.notFound` | `"NOT_FOUND"` | 404 |
+| `ERROR_CODE.validation` | `"VALIDATION_ERROR"` | 400 |
+| `ERROR_CODE.internal` | `"INTERNAL_ERROR"` | 500 |
+| `ERROR_CODE.conflict` | `"CONFLICT"` | 409 |
+
+---
+
+## Service Functions
+
+Services live in `src/application/services/`. Each file exports one or more pure functions that accept `DbClient` as the first argument and a typed input as the second:
+
+```ts
+export interface SendContextInput {
+  conversation: string;
+  sender: string;
+  recipient: string;
+  payload: string;
+  meta_prompt?: string;
+}
+
+export function sendContext(db: DbClient, input: SendContextInput): AppResult<MessageRow> {
+  const row = db.insertMessage({
+    conversation: input.conversation,
+    sender: input.sender,
+    recipient: input.recipient,
+    kind: "context",
+    payload: input.payload,
+    meta_prompt: input.meta_prompt ?? null,
+  });
+  return ok(row);
+}
+```
+
+Rules:
+- First parameter is always `DbClient`.
+- Define an `*Input` interface for the second parameter.
+- Return `AppResult<T>`, never throw.
+- Use `db.transaction()` when multiple writes must be atomic.
+- Validate preconditions (e.g., check existence) **before** any writes.
+
+---
+
+## `RouteSchema` / `defineRoute` Pattern
+
+Route definitions live in `src/routes/`. Each file exports a function `create*Routes(db: DbClient): ControllerDefinition`.
+
+A `RouteSchema` object bundles Zod schemas for `body`, `params`, `querystring`, and `response`:
+
+```ts
+export const SendContextSchema = {
+  body: SendContextBodySchema,
+  response: MessageResponseSchema,
+} as const;
+export type SendContextSchema = typeof SendContextSchema;
+```
+
+Routes are registered using the `defineRoute` identity function, which captures the schema type parameter at compile time:
+
+```ts
+defineRoute({
+  method: "POST",
+  path: "/send",
+  summary: "Send context from one agent to another",
+  schema: SendContextSchema,
+  handler: handlers.send,
+})
+```
+
+The `handler` function receives a fully typed `ApiRequest<TSchema>` where `body`, `params`, and `query` are inferred from the schema. The server (`server.ts`) handles Zod validation automatically -- handlers never call `.parse()` themselves.
+
+---
+
+## Zod Schema Naming
+
+Schemas follow a consistent pattern with companion type aliases:
+
+```ts
+// 1. Define the Zod schema with PascalCase + Schema suffix
+export const MessageResponseSchema = z.object({
+  id: z.string().uuid(),
+  conversation: z.string().uuid(),
+  sender: z.string(),
+  // ...
+});
+
+// 2. Export a companion type alias using z.infer
+export type MessageResponse = z.infer<typeof MessageResponseSchema>;
+```
+
+For route-level schema objects that are used as both a value and a type (the "dual declaration" pattern):
+
+```ts
+// Value -- the actual object containing Zod schemas
+export const GetMessagesSchema = {
+  params: ConversationParamsSchema,
+  response: z.array(MessageResponseSchema),
+} as const;
+
+// Type -- used in ApiRequest<GetMessagesSchema>
+export type GetMessagesSchema = typeof GetMessagesSchema;
+```
+
+This dual declaration is required because TypeScript uses the value in `defineRoute()` and the type in `ApiRequest<T>` generics.
+
+---
+
+## Controller Pattern
+
+Controllers live in `src/transport/controllers/`. Each file exports a factory function that receives `DbClient` and returns an object of handler methods:
+
+```ts
+export function createMessageController(db: DbClient) {
+  return {
+    async send(req: ApiRequest<SendContextSchema>): Promise<ApiResponse<MessageResponse>> {
+      const result = sendContext(db, req.body);
+      if (!result.ok) return appErr(result.error);
+      return { ok: true, data: result.data };
+    },
+    // ...
+  };
+}
+```
+
+Controllers are thin: they forward to service functions and translate `AppResult` into `ApiResponse`. The `appErr()` helper converts an `AppError` into the `ApiResponse` error shape.
+
+---
+
+## Test File Conventions
+
+Tests use **vitest** and live in the `tests/` directory at the package root. File naming: `*.test.ts`.
+
+### Setup
+
+Each test file creates an in-memory SQLite database per test:
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { createDbClient, type DbClient } from "../src/db/client.js";
+import { MIGRATIONS } from "../src/db/schema.js";
+
+let db: DbClient;
+
+beforeEach(() => {
+  const raw = new Database(":memory:");
+  raw.pragma("journal_mode = WAL");
+  raw.exec(MIGRATIONS);
+  db = createDbClient(raw);
+});
+```
+
+### Assertions
+
+- Use `result.ok` discriminator checks before accessing `.data` or `.error`:
+  ```ts
+  expect(result.ok).toBe(true);
+  if (!result.ok) return; // narrows the type
+  expect(result.data.conversation).toBe(conv);
+  ```
+- Test both success and error paths.
+- For atomic operations, verify that failed operations leave no orphaned records:
+  ```ts
+  // Verify no orphaned message was created
+  const msgs = getMessagesByConversation(db, conv);
+  expect(msgs.ok).toBe(true);
+  if (!msgs.ok) return;
+  expect(msgs.data).toHaveLength(0);
+  ```
+
+### Test Organization
+
+- Group by service function using `describe()`.
+- Use descriptive `it()` strings that state the expected behavior.
+- Use `randomUUID()` for test isolation -- each test gets unique conversation IDs.
+
+---
+
+## Section Comment Style
+
+Use ASCII box-drawing headers to separate logical sections within a file:
+
+```ts
+// ── Row types ──────────────────────────────────────────────
+
+// ── Database client ────────────────────────────────────────
+
+// ── Error helper ───────────────────────────────────────────
+```
+
+Use `/** JSDoc */` comments for interface and function documentation, not `//`.

--- a/planning/COMMIT_STRATEGY.md
+++ b/planning/COMMIT_STRATEGY.md
@@ -1,0 +1,149 @@
+# Commit Strategy
+
+This document defines how commits are structured, messaged, and branched in the agentic-workflow repository.
+
+---
+
+## Conventional Commit Format
+
+Every commit message follows the [Conventional Commits](https://www.conventionalcommits.org/) specification:
+
+```
+<type>: <subject>
+```
+
+Or with an optional scope:
+
+```
+<type>(<scope>): <subject>
+```
+
+### Types
+
+| Type | When to use | Example |
+|------|-------------|---------|
+| `feat` | New feature or capability | `feat: initial agentic-workflow toolkit` |
+| `fix` | Bug fix or correctness improvement | `fix: address review findings -- atomicity, security, DX` |
+| `docs` | Documentation-only changes | `docs: add planning documents` |
+| `chore` | Build config, dependencies, tooling | `chore: upgrade vitest to v3` |
+| `refactor` | Code restructuring without behavior change | `refactor: extract message validation to shared helper` |
+| `test` | Adding or updating tests | `test: add edge case for empty conversation` |
+| `style` | Formatting, whitespace (no logic change) | `style: fix trailing commas in schemas` |
+
+### Scope (optional)
+
+Scope narrows the area of change. Use the package or module name:
+
+```
+feat(mcp-bridge): add batch message endpoint
+fix(db): handle null analysis in task update
+test(services): cover reportStatus error path
+```
+
+---
+
+## Subject Line Rules
+
+| Rule | Correct | Incorrect |
+|------|---------|-----------|
+| Lowercase first word | `fix: address review findings` | `Fix: Address review findings` |
+| No period at end | `feat: add task assignment` | `feat: add task assignment.` |
+| Imperative mood | `fix: validate task existence before write` | `fix: validated task existence before write` |
+| Concise (under 72 chars) | `fix: address review findings` | `fix: I fixed the review findings that were found during the code review` |
+| Describe the "why" when possible | `fix: address review findings -- atomicity, security, DX` | `fix: change some code` |
+
+The subject should complete the sentence: "This commit will ___."
+
+---
+
+## Body Format
+
+For non-trivial changes, add a body separated by a blank line. Use the body to explain **what** changed and **why**:
+
+```
+fix: address review findings -- atomicity, security, DX
+
+- Wrap reportStatus in db.transaction() for atomic message + task update
+- Validate task existence before any writes to prevent orphaned messages
+- Restrict default bind to loopback (127.0.0.1) with ALLOW_REMOTE escape hatch
+- Add getUnread mark-read atomicity via transaction
+```
+
+Body guidelines:
+- Wrap lines at ~72 characters.
+- Use bullet points (`-`) for multiple changes.
+- Reference issue numbers if applicable: `Closes #42`.
+
+---
+
+## What Makes a Good Commit
+
+### Good: atomic and focused
+
+```
+feat: add batch message endpoint
+
+Adds POST /messages/batch for sending multiple context messages
+in a single transaction. Includes Zod validation and tests.
+```
+
+```
+fix: address review findings -- atomicity, security, DX
+
+- Wrap reportStatus in db.transaction() for atomic message + task update
+- Validate task existence before any writes to prevent orphaned messages
+- Restrict default bind to loopback (127.0.0.1) with ALLOW_REMOTE escape hatch
+```
+
+### Bad: vague or mixed
+
+```
+update code
+```
+
+```
+fix stuff and add some features
+```
+
+```
+WIP
+```
+
+---
+
+## Branch Naming
+
+Branches use a type prefix followed by a `/` and a kebab-case descriptor:
+
+| Pattern | Example |
+|---------|---------|
+| `feat/<description>` | `feat/batch-messages` |
+| `fix/<description>` | `fix/orphaned-message-on-failed-task` |
+| `docs/<description>` | `docs/planning-docs` |
+| `chore/<description>` | `chore/upgrade-fastify-v5` |
+| `refactor/<description>` | `refactor/extract-validation` |
+| `test/<description>` | `test/report-status-edge-cases` |
+
+Branch names should be short but descriptive. Use the same type prefixes as commit messages.
+
+---
+
+## Commit Granularity
+
+Prefer **small, atomic commits** that each represent one logical change:
+
+- One commit per feature, bug fix, or refactor step.
+- If a fix requires changes across multiple layers (service, controller, schema, test), those go in a single commit -- they are one logical change.
+- Avoid mixing unrelated changes in the same commit.
+- "Fix review findings" commits are acceptable when addressing a batch of related feedback, but use bullet points in the body to enumerate changes.
+
+---
+
+## Examples From This Repository
+
+```
+6176148 feat: initial agentic-workflow toolkit
+a0d0755 fix: address review findings -- atomicity, security, DX
+```
+
+The first commit is a large initial scaffold (acceptable for project bootstrapping). The second is a targeted fix commit addressing specific review feedback, with the subject summarizing the themes (atomicity, security, DX) and the body (if present) enumerating individual changes.

--- a/planning/COMPETITIVE_ANALYSIS.md
+++ b/planning/COMPETITIVE_ANALYSIS.md
@@ -1,0 +1,135 @@
+# Competitive Analysis
+
+## Overview
+
+The multi-agent bridge space is emerging rapidly alongside Claude Code and OpenAI Codex adoption. Several projects attempt to solve similar problems — enabling communication between AI coding agents. This analysis compares agentic-workflow against five discovered alternatives.
+
+---
+
+## Competitor Profiles
+
+### 1. codex-bridge (Python, Stateless)
+
+**Overview:** A Python-based bridge that relays messages between Claude Code and Codex. Designed as a lightweight relay with no persistence layer — messages are forwarded in real-time and not stored.
+
+**Strengths:**
+- Simple architecture — easy to understand and deploy
+- Python ecosystem is familiar to a broad developer audience
+- Low overhead — no database, no disk I/O for message storage
+- Fast startup time due to minimal dependencies
+
+**Weaknesses:**
+- Stateless design means messages are lost if the recipient agent is not running when a message is sent — no store-and-forward capability
+- No conversation history — agents cannot review prior exchanges
+- No task management — only raw message passing
+- Python runtime requirement adds friction for Node.js/TypeScript-focused developers
+- No structured error handling or validation layer
+
+### 2. claude-codex-bridge (Planning-First)
+
+**Overview:** A bridge that emphasizes planning and coordination before execution. Agents negotiate a plan through the bridge before proceeding with implementation. Focuses on the orchestration pattern rather than raw message delivery.
+
+**Strengths:**
+- Planning-first approach reduces wasted work — agents agree on approach before coding
+- Structured workflow templates for common patterns (divide-and-conquer, review-revise)
+- Good conceptual documentation of multi-agent coordination patterns
+- Encourages deliberate task decomposition
+
+**Weaknesses:**
+- Opinionated workflow — forces a planning phase that may not suit all use cases
+- Less flexible for ad-hoc agent communication
+- Tighter coupling between agents — both must understand the planning protocol
+- May add latency for simple task delegation where planning overhead is not warranted
+- Limited to the planning patterns the bridge defines
+
+### 3. codex-mcp-server (TypeScript, Sessions)
+
+**Overview:** A TypeScript MCP server that introduces session management for agent conversations. Each session maintains state, and agents connect to named sessions to communicate.
+
+**Strengths:**
+- TypeScript — same language as agentic-workflow, familiar to the target audience
+- Session-based model provides natural conversation boundaries
+- MCP protocol compliance for Claude Code integration
+- Active development with regular updates
+
+**Weaknesses:**
+- Session management adds complexity — sessions must be created, joined, and cleaned up
+- No task management beyond messaging
+- Session-centric model may not map well to long-running workflows that span multiple sessions
+- No REST API — MCP stdio only, limiting integration options for non-MCP clients
+- No built-in skill system or workflow automation
+
+### 4. claude-code-mcp (Claude as MCP Server)
+
+**Overview:** Wraps Claude Code itself as an MCP server, allowing other tools and agents to invoke Claude Code capabilities through the MCP protocol. The focus is on making Claude Code's abilities available as MCP tools rather than inter-agent communication.
+
+**Strengths:**
+- Leverages Claude Code's full capability set through MCP
+- Enables non-agent tools (IDEs, scripts, CI pipelines) to invoke Claude Code
+- Well-aligned with the MCP ecosystem direction
+- Clean single-responsibility design
+
+**Weaknesses:**
+- Solves a different problem — exposes Claude Code as a service rather than enabling agent-to-agent communication
+- No message persistence or conversation history
+- No task assignment or workflow coordination
+- Uni-directional — tools call Claude Code, but Claude Code does not call back through the same channel
+- Not designed for multi-agent scenarios where multiple AI agents coordinate
+
+### 5. ai-cli-mcp (Multi-Agent Orchestrator)
+
+**Overview:** A multi-agent orchestrator that manages multiple AI CLI tools (Claude Code, Codex, Gemini CLI) from a central coordinator. Focuses on dispatching work to the right agent based on capabilities and availability.
+
+**Strengths:**
+- Multi-model support out of the box — not limited to Claude and Codex
+- Central orchestrator pattern simplifies coordination logic
+- Agent capability registry — knows what each agent can do
+- Built-in load balancing and failover between agents
+
+**Weaknesses:**
+- Centralized architecture creates a single point of failure
+- Orchestrator must understand all agent capabilities — adding new agents requires orchestrator changes
+- Heavier operational overhead — the orchestrator itself is a long-running service
+- Less flexible for peer-to-peer agent communication
+- May over-engineer simple two-agent workflows
+
+---
+
+## Positioning Matrix
+
+| Capability | agentic-workflow | codex-bridge | claude-codex-bridge | codex-mcp-server | claude-code-mcp | ai-cli-mcp |
+|---|---|---|---|---|---|---|
+| **Language** | TypeScript | Python | Mixed | TypeScript | TypeScript | TypeScript |
+| **Message Persistence** | SQLite store-and-forward | None (stateless) | Planning docs only | Session-scoped | None | Orchestrator state |
+| **Task Management** | Full (assign, status, domain) | None | Planning tasks | None | None | Dispatch queue |
+| **MCP Protocol** | Yes (stdio) | No | Partial | Yes (stdio) | Yes (server) | Yes |
+| **REST API** | Yes (Fastify, port 3100) | No | No | No | No | Partial |
+| **Conversation History** | Full (queryable by UUID) | None | Planning history | Session-scoped | None | Limited |
+| **Offline Tolerance** | Yes (store-and-forward) | No (real-time only) | Partial | Session-dependent | No | Orchestrator buffers |
+| **Skill System** | 5 skills + bootstrap | None | Workflow templates | None | None | Agent registry |
+| **Multi-Model** | Claude + Codex | Claude + Codex | Claude + Codex | Claude + Codex | Claude only | Claude + Codex + Gemini |
+| **Type Safety** | Full (Zod + AppResult\<T\>) | Runtime only | Partial | TypeScript | TypeScript | TypeScript |
+| **Transaction Safety** | SQLite transactions | N/A | None | None | N/A | None |
+| **Setup Complexity** | Low (setup.sh) | Low (pip install) | Medium | Low | Low | Medium-High |
+| **Architecture** | Peer-to-peer + shared DB | Relay | Planning coordinator | Session server | Tool server | Central orchestrator |
+
+## Differentiation Summary
+
+Agentic-workflow occupies a distinct position in this space through three differentiators:
+
+**1. Store-and-forward persistence.** Unlike stateless relays (codex-bridge) or session-scoped stores (codex-mcp-server), agentic-workflow persists all messages and tasks in SQLite with WAL mode and atomic transactions. Agents can go offline and pick up messages later. Conversation history is queryable indefinitely.
+
+**2. Integrated skill library.** No other bridge project ships production-ready Claude Code skills. The `/review` pipeline (triage, parallel domain reviewers, structured findings, GitHub posting) is a complete workflow that demonstrates the bridge's value rather than just providing infrastructure.
+
+**3. Dual transport with zero lock-in.** The same application services power both the MCP stdio server and the Fastify REST API. Non-MCP clients (scripts, CI pipelines, dashboards) can interact with the bridge over HTTP. The custom router avoids framework-specific coupling, making the HTTP layer replaceable.
+
+**Where agentic-workflow trails:**
+- Multi-model support is narrower than ai-cli-mcp (currently Claude + Codex only, though the protocol is model-agnostic)
+- No planning-first workflow pattern like claude-codex-bridge (agents communicate freely without structured negotiation)
+- No centralized orchestration — coordination is emergent from agent behavior rather than centrally managed
+
+## Strategic Recommendation
+
+The primary competitive advantage is the combination of infrastructure (bridge) and application (skills) in a single portable toolkit. Competitors provide one or the other. Maintaining this integrated approach — where new skills demonstrate new bridge capabilities and new bridge features enable new skill patterns — is the strongest differentiator to preserve.
+
+The most impactful gap to close is multi-model support (v2.0 roadmap item), since the bridge protocol is already model-agnostic and the limitation is purely in documentation and skill design. Adding Gemini CLI support would match ai-cli-mcp's breadth while retaining the persistence and skill advantages.

--- a/planning/DEPENDENCY_GRAPH.md
+++ b/planning/DEPENDENCY_GRAPH.md
@@ -1,0 +1,135 @@
+# Dependency Graph
+
+## Runtime Environment
+
+| Requirement | Value |
+|-------------|-------|
+| Node.js | >= 20 |
+| TypeScript target | ES2022 |
+| Module system | Node16 (ESM — `"type": "module"` in package.json) |
+| Module resolution | Node16 |
+| Strict mode | Enabled |
+
+## Runtime Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `@modelcontextprotocol/sdk` | ^1.12.1 | MCP server implementation — provides `McpServer` class and `StdioServerTransport` for exposing tools over the MCP stdio protocol |
+| `better-sqlite3` | ^11.7.0 | Synchronous SQLite3 driver — used for the store-and-forward message queue and task persistence with WAL journal mode |
+| `fastify` | ^5.2.1 | HTTP framework — serves the REST API on port 3100 with built-in logging; used only as a listener/router, no plugins or middleware |
+| `zod` | ^3.24.2 | Schema validation — defines input/output shapes for both MCP tool parameters and REST API request bodies, params, and querystrings |
+
+## Dev Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `@types/better-sqlite3` | ^7.6.12 | TypeScript type definitions for better-sqlite3 |
+| `@types/node` | ^22.10.0 | TypeScript type definitions for Node.js built-in modules |
+| `tsx` | ^4.19.0 | TypeScript execution engine — runs `.ts` files directly for `npm run dev` without a build step |
+| `typescript` | ^5.7.0 | TypeScript compiler — targets ES2022, emits declarations and source maps |
+| `vitest` | ^2.1.9 | Test runner — configured for `vitest run` (single pass) and `vitest` (watch mode) |
+
+## No Framework Lock-in
+
+The project uses Fastify as a thin HTTP listener but does not depend on Fastify-specific features such as plugins, decorators, hooks, or serialization. The custom router in `server.ts` registers routes via a generic `ControllerDefinition` interface and performs Zod validation manually rather than using Fastify's schema validation. This means the HTTP layer could be swapped for any framework (Express, Hono, bare `node:http`) by reimplementing the ~90-line `createServer` function without touching application or domain logic.
+
+## Layer Dependency Map
+
+```
+Entry Points
+├── index.ts (REST API)
+│   ├── db/schema.ts .............. createDatabase()
+│   ├── db/client.ts .............. createDbClient()
+│   ├── routes/messages.ts ........ createMessageRoutes()
+│   ├── routes/tasks.ts ........... createTaskRoutes()
+│   └── server.ts ................. createServer()
+│
+└── mcp.ts (MCP stdio server)
+    ├── db/schema.ts .............. createDatabase()
+    ├── db/client.ts .............. createDbClient()
+    └── application/services/*.ts .. service functions directly
+
+Routes Layer (routes/)
+├── routes/messages.ts
+│   ├── transport/controllers/message-controller.ts
+│   ├── transport/types.ts ........ defineRoute, ControllerDefinition
+│   └── transport/schemas/message-schemas.ts
+│
+└── routes/tasks.ts
+    ├── transport/controllers/task-controller.ts
+    ├── transport/types.ts ........ defineRoute, ControllerDefinition
+    └── transport/schemas/task-schemas.ts
+
+Transport Layer (transport/)
+├── controllers/message-controller.ts
+│   ├── application/services/send-context.ts
+│   ├── application/services/get-messages.ts
+│   └── transport/types.ts ........ ApiRequest, ApiResponse, appErr
+│
+├── controllers/task-controller.ts
+│   ├── application/services/assign-task.ts
+│   ├── application/services/report-status.ts
+│   ├── application/result.ts ..... ERROR_CODE
+│   └── transport/types.ts ........ ApiRequest, ApiResponse, appErr
+│
+├── types.ts ...................... RouteSchema, RouteEntry, ControllerDefinition
+│   └── zod (external) ........... ZodType
+│
+└── schemas/ ...................... Zod schema definitions (no internal deps)
+
+Application Layer (application/)
+├── result.ts ..................... AppResult<T>, ok(), err(), ERROR_CODE
+│
+├── services/send-context.ts
+│   ├── db/client.ts .............. DbClient type
+│   └── application/result.ts ..... AppResult, ok
+│
+├── services/get-messages.ts
+│   ├── db/client.ts .............. DbClient type
+│   └── application/result.ts ..... AppResult, ok
+│
+├── services/assign-task.ts
+│   ├── db/client.ts .............. DbClient type
+│   └── application/result.ts ..... AppResult, ok
+│
+└── services/report-status.ts
+    ├── db/client.ts .............. DbClient type
+    └── application/result.ts ..... AppResult, ok, err, ERROR_CODE
+
+Database Layer (db/)
+├── schema.ts ..................... createDatabase(), MIGRATIONS SQL
+│   └── better-sqlite3 (external)
+│
+└── client.ts ..................... DbClient interface, createDbClient()
+    ├── better-sqlite3 (external) . Database type
+    └── node:crypto ............... randomUUID()
+```
+
+## Dependency Direction
+
+Dependencies flow strictly downward:
+
+```
+  Entry Points (index.ts, mcp.ts)
+         │
+    Routes Layer (routes/)
+         │
+   Transport Layer (transport/)
+         │
+  Application Layer (application/)
+         │
+    Database Layer (db/)
+         │
+   External Packages + Node built-ins
+```
+
+No circular dependencies exist. The application layer never imports from the transport or routes layers. The database layer never imports from any layer above it. The MCP entry point bypasses the routes/transport layers entirely and calls service functions directly, which is why both transports (REST and MCP stdio) can coexist without coupling.
+
+## External System Dependencies
+
+| System | Binding | Required By |
+|--------|---------|-------------|
+| SQLite (via better-sqlite3) | File-based, default `./bridge.db` | MCP bridge data persistence |
+| GitHub CLI (`gh`) | Shell command | Skills (review, postReview, addressReview) |
+| Claude Code | CLI tool | Skills execution, MCP server registration |
+| Node.js native modules | `node:crypto` (randomUUID), `node:path` (join) | db/client.ts, db/schema.ts |

--- a/planning/DEPLOYMENT.md
+++ b/planning/DEPLOYMENT.md
@@ -1,0 +1,188 @@
+# Deployment Guide
+
+## Deployment Model
+
+This project runs **locally only**. There is no cloud deployment, no containerization, and no remote hosting. The MCP bridge runs on the developer's machine alongside Claude Code and Codex CLI.
+
+## Building for Production
+
+```bash
+cd ~/repos/agentic-workflow/mcp-bridge
+npm install
+npm run build
+```
+
+This compiles TypeScript from `src/` to `dist/` using `tsc`. The production entry points are:
+
+| Entry Point | File | Purpose |
+|-------------|------|---------|
+| REST API | `dist/index.js` | Fastify server on port 3100 |
+| MCP Server | `dist/mcp.js` | Stdio-based MCP server for Claude Code / Codex |
+
+## Registering the MCP Server
+
+### Claude Code
+
+```bash
+claude mcp add agentic-bridge -- node ~/repos/agentic-workflow/mcp-bridge/dist/mcp.js
+```
+
+This registers `agentic-bridge` as a stdio MCP server. Claude Code will spawn the process on demand and communicate via stdin/stdout. The server exposes five tools:
+
+- `send_context` -- Send task context and meta-prompt between agents
+- `get_messages` -- Retrieve conversation history by UUID
+- `get_unread` -- Check for unread messages (marks as read on retrieval)
+- `assign_task` -- Assign tasks with domain and implementation details
+- `report_status` -- Report back with feedback or completion status
+
+### Codex CLI
+
+```bash
+codex mcp add agentic-bridge -- node ~/repos/agentic-workflow/mcp-bridge/dist/mcp.js
+```
+
+Same registration pattern. Both Claude Code and Codex share the same SQLite database file, enabling bidirectional communication between the two agents.
+
+### MCP Config File
+
+The setup script copies `config/mcp.json` to `~/.claude/mcp.json` if one does not already exist. This file can also contain the MCP server registration. To check or update the config manually:
+
+```bash
+diff ~/.claude/mcp.json ~/repos/agentic-workflow/config/mcp.json
+```
+
+## SQLite Database
+
+### Location
+
+By default, the database file is created at `./bridge.db` relative to the working directory when the server starts. This can be overridden:
+
+```bash
+# Via environment variable
+DB_PATH=~/data/bridge.db npm start
+
+# Or in .env file
+DB_PATH=/Users/you/data/bridge.db
+```
+
+The `createDatabase` function in `src/db/schema.ts` resolves the path:
+
+```ts
+const resolvedPath = dbPath ?? join(process.cwd(), "bridge.db");
+```
+
+### Schema
+
+The database has two tables:
+
+**messages** -- Store-and-forward message queue between agents:
+- `id` (TEXT PRIMARY KEY)
+- `conversation` (TEXT) -- UUID grouping related messages
+- `sender` / `recipient` (TEXT) -- Agent identifiers
+- `kind` (TEXT) -- One of: `context`, `task`, `status`, `reply`
+- `payload` (TEXT) -- Message content
+- `meta_prompt` (TEXT, nullable) -- Processing instructions for recipient
+- `created_at` / `read_at` (TEXT) -- Timestamps
+
+**tasks** -- Task tracking with status lifecycle:
+- `id` (TEXT PRIMARY KEY)
+- `conversation` (TEXT) -- Links to a message conversation
+- `domain` (TEXT) -- e.g., `frontend`, `backend`, `security`
+- `summary` / `details` / `analysis` (TEXT)
+- `assigned_to` (TEXT, nullable)
+- `status` (TEXT) -- One of: `pending`, `in_progress`, `completed`, `failed`
+- `created_at` / `updated_at` (TEXT)
+
+### Pragmas
+
+The database is initialized with:
+- `journal_mode = WAL` -- Write-Ahead Logging for concurrent read/write
+- `foreign_keys = ON` -- Enforces referential integrity
+
+### Backup
+
+Since the database is a single SQLite file, backup is straightforward:
+
+```bash
+# Simple file copy (safe when server is stopped)
+cp ~/repos/agentic-workflow/mcp-bridge/bridge.db ~/backups/bridge-$(date +%Y%m%d).db
+
+# Online backup using SQLite CLI (safe while server is running)
+sqlite3 ~/repos/agentic-workflow/mcp-bridge/bridge.db ".backup '~/backups/bridge-$(date +%Y%m%d).db'"
+```
+
+To start fresh, simply delete the database file. It will be recreated with the schema on next server start.
+
+## Skills Deployment
+
+Skills are deployed via **symlinks** managed by `setup.sh`. The script links directories from the repo into `~/.claude/skills/`:
+
+```
+~/.claude/skills/review        -> ~/repos/agentic-workflow/skills/review
+~/.claude/skills/postReview    -> ~/repos/agentic-workflow/skills/postReview
+~/.claude/skills/addressReview -> ~/repos/agentic-workflow/skills/addressReview
+~/.claude/skills/enhancePrompt -> ~/repos/agentic-workflow/skills/enhancePrompt
+~/.claude/skills/bootstrap     -> ~/repos/agentic-workflow/bootstrap
+```
+
+Because these are symlinks, any changes to skill files in the repo are immediately reflected -- no reinstallation needed. The symlink approach means:
+
+- `git pull` in the repo updates all skills instantly.
+- Skills can be version-controlled and reviewed via normal Git workflow.
+- Multiple machines stay in sync by pulling and re-running `setup.sh` if new skills are added.
+
+### Adding a New Skill
+
+1. Create the skill directory under `skills/` (or at the repo root for standalone skills like `bootstrap`).
+2. Add the skill name to the `for` loop in `setup.sh`:
+   ```bash
+   for skill in review postReview addressReview enhancePrompt newSkillName; do
+   ```
+3. Run `./setup.sh` on each machine to create the symlink.
+
+## New Machine Onboarding
+
+Full setup from scratch:
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/joi-fairshare/agentic-workflow.git ~/repos/agentic-workflow
+cd ~/repos/agentic-workflow
+
+# 2. Run the setup script (installs skills, config, and npm dependencies)
+./setup.sh
+
+# 3. Build the MCP bridge
+cd mcp-bridge
+npm run build
+
+# 4. Register the MCP server with Claude Code
+claude mcp add agentic-bridge -- node ~/repos/agentic-workflow/mcp-bridge/dist/mcp.js
+
+# 5. (Optional) Register with Codex CLI
+codex mcp add agentic-bridge -- node ~/repos/agentic-workflow/mcp-bridge/dist/mcp.js
+
+# 6. (Optional) Start the REST API server
+npm start
+```
+
+The setup script handles:
+- Symlinking all skills to `~/.claude/skills/`
+- Copying `settings.json` and `mcp.json` to `~/.claude/` (non-destructive -- skips if files exist)
+- Running `npm install` in `mcp-bridge/`
+
+After setup, it prints a reminder for manual plugin installations:
+- claude-plugins-official (Anthropic official)
+- voltagent-subagents (subagent catalog)
+- compound-engineering-plugin (EveryInc/compound-engineering-plugin)
+
+## Environment Variables Reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `3100` | REST API port |
+| `HOST` | `127.0.0.1` | Bind address (loopback only by default) |
+| `DB_PATH` | `./bridge.db` | SQLite database file path |
+| `ALLOW_REMOTE` | unset | Set to `1` to allow non-loopback binding (not recommended) |
+
+The server will refuse to start if `HOST` is set to a non-loopback address without `ALLOW_REMOTE=1`, since the server has no authentication.

--- a/planning/ERD.md
+++ b/planning/ERD.md
@@ -1,0 +1,111 @@
+# Entity-Relationship Diagram -- MCP Bridge
+
+## Relationships
+
+```mermaid
+erDiagram
+    messages {
+        TEXT id PK "UUIDv4"
+        TEXT conversation "NOT NULL, UUIDv4"
+        TEXT sender "NOT NULL"
+        TEXT recipient "NOT NULL"
+        TEXT kind "NOT NULL, CHECK"
+        TEXT payload "NOT NULL"
+        TEXT meta_prompt "NULLABLE"
+        TEXT created_at "NOT NULL, DEFAULT datetime('now')"
+        TEXT read_at "NULLABLE"
+    }
+
+    tasks {
+        TEXT id PK "UUIDv4"
+        TEXT conversation "NOT NULL, UUIDv4"
+        TEXT domain "NOT NULL"
+        TEXT summary "NOT NULL"
+        TEXT details "NOT NULL"
+        TEXT analysis "NULLABLE"
+        TEXT assigned_to "NULLABLE"
+        TEXT status "NOT NULL, DEFAULT 'pending', CHECK"
+        TEXT created_at "NOT NULL, DEFAULT datetime('now')"
+        TEXT updated_at "NOT NULL, DEFAULT datetime('now')"
+    }
+
+    tasks ||--o{ messages : "assign_task creates a 'task' message; report_status creates a 'status' message"
+```
+
+There are no foreign-key constraints between `messages` and `tasks`. The relationship is enforced at the application layer:
+
+- **assign_task** inserts one `tasks` row and one `messages` row (kind = `'task'`, payload contains `task_id`) inside a single transaction.
+- **report_status** inserts one `messages` row (kind = `'status'`) and optionally updates the referenced `tasks` row (by `task_id`) inside a single transaction.
+- Both tables share a `conversation` UUID that acts as a logical grouping key, but there is no FK constraint enforcing referential integrity.
+
+---
+
+### `messages`
+
+Stores all inter-agent messages: context pushes, task notifications, status reports, and replies.
+
+| Field | Type | Nullable | Notes |
+|---|---|---|---|
+| `id` | TEXT (UUIDv4) | NOT NULL | Primary key. Generated server-side via `crypto.randomUUID()`. |
+| `conversation` | TEXT (UUIDv4) | NOT NULL | Groups messages into a logical conversation thread. |
+| `sender` | TEXT | NOT NULL | Identifier of the sending agent (e.g. `"claude-code"`, `"codex"`). |
+| `recipient` | TEXT | NOT NULL | Identifier of the receiving agent. |
+| `kind` | TEXT | NOT NULL | Message type. **CHECK constraint:** must be one of `'context'`, `'task'`, `'status'`, `'reply'`. |
+| `payload` | TEXT | NOT NULL | Free-form content. For kind `'task'`, this is a JSON object containing `task_id`, `domain`, `summary`, `details`. |
+| `meta_prompt` | TEXT | Yes | Optional guidance for how the recipient should process the message. Only set on `'context'` messages. |
+| `created_at` | TEXT (ISO 8601) | NOT NULL | Insertion timestamp. **DEFAULT:** `datetime('now')`. |
+| `read_at` | TEXT (ISO 8601) | Yes | Set when the message is marked as read. `NULL` means unread. |
+
+**Indexes:**
+
+| Index Name | Columns | Purpose |
+|---|---|---|
+| `idx_messages_conversation` | `conversation` | Fast lookup of all messages in a conversation. |
+| `idx_messages_recipient` | `recipient, read_at` | Fast lookup of unread messages for a given recipient (`WHERE recipient = ? AND read_at IS NULL`). |
+
+**CHECK constraints:**
+
+| Column | Constraint |
+|---|---|
+| `kind` | `kind IN ('context', 'task', 'status', 'reply')` |
+
+---
+
+### `tasks`
+
+Stores task assignments with domain classification, implementation details, and lifecycle status.
+
+| Field | Type | Nullable | Notes |
+|---|---|---|---|
+| `id` | TEXT (UUIDv4) | NOT NULL | Primary key. Generated server-side via `crypto.randomUUID()`. |
+| `conversation` | TEXT (UUIDv4) | NOT NULL | Links this task to a conversation thread. |
+| `domain` | TEXT | NOT NULL | Task domain classifier (e.g. `"frontend"`, `"backend"`, `"security"`). |
+| `summary` | TEXT | NOT NULL | Brief one-line task summary. |
+| `details` | TEXT | NOT NULL | Full implementation instructions. |
+| `analysis` | TEXT | Yes | Analysis or research notes. Can be set at creation or updated via `report_status`. On status update, only overwritten if a new value is provided (`COALESCE(@analysis, analysis)`). |
+| `assigned_to` | TEXT | Yes | Agent identifier the task is assigned to. `NULL` means unassigned. |
+| `status` | TEXT | NOT NULL | Lifecycle state. **DEFAULT:** `'pending'`. **CHECK constraint:** must be one of `'pending'`, `'in_progress'`, `'completed'`, `'failed'`. |
+| `created_at` | TEXT (ISO 8601) | NOT NULL | Insertion timestamp. **DEFAULT:** `datetime('now')`. |
+| `updated_at` | TEXT (ISO 8601) | NOT NULL | Last-modified timestamp. **DEFAULT:** `datetime('now')`. Updated on every `updateTaskStatus` call. |
+
+**Indexes:**
+
+| Index Name | Columns | Purpose |
+|---|---|---|
+| `idx_tasks_conversation` | `conversation` | Fast lookup of all tasks in a conversation. |
+| `idx_tasks_status` | `status` | Fast filtering by task lifecycle state. |
+
+**CHECK constraints:**
+
+| Column | Constraint |
+|---|---|
+| `status` | `status IN ('pending', 'in_progress', 'completed', 'failed')` |
+
+---
+
+## Database Configuration
+
+- **Engine:** SQLite via `better-sqlite3`
+- **Journal mode:** WAL (`PRAGMA journal_mode = WAL`)
+- **Foreign keys:** Enabled (`PRAGMA foreign_keys = ON`), though no FK constraints are currently defined
+- **Default path:** `bridge.db` in the process working directory

--- a/planning/LOCAL_DEV.md
+++ b/planning/LOCAL_DEV.md
@@ -1,0 +1,195 @@
+# Local Development Guide
+
+## Prerequisites
+
+| Requirement | Minimum Version | Purpose |
+|-------------|----------------|---------|
+| Node.js | >= 20 | Runtime for MCP bridge and build tooling |
+| GitHub CLI (`gh`) | Latest | Required by review skills for PR interaction |
+| Claude Code | Latest | Host for skills and MCP server registration |
+| npm | Bundled with Node | Dependency management |
+
+## Initial Setup
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/joi-fairshare/agentic-workflow.git ~/repos/agentic-workflow
+cd ~/repos/agentic-workflow
+```
+
+### 2. Run the Setup Script
+
+```bash
+./setup.sh
+```
+
+The setup script performs the following:
+
+1. **Symlinks skills** into `~/.claude/skills/`:
+   - `review`, `postReview`, `addressReview`, `enhancePrompt`, `bootstrap`
+   - If a directory already exists (not a symlink), it prompts before replacing.
+
+2. **Copies config files** to `~/.claude/`:
+   - `settings.json` -- only if no existing file (will not overwrite).
+   - `mcp.json` -- only if no existing file (will not overwrite).
+   - If files exist, it prints a `diff` command for manual comparison.
+
+3. **Installs MCP bridge dependencies**:
+   - Runs `npm install` inside `mcp-bridge/`.
+
+### 3. Build the MCP Bridge
+
+```bash
+cd ~/repos/agentic-workflow/mcp-bridge
+npm run build
+```
+
+This runs `tsc` and outputs compiled JavaScript to `mcp-bridge/dist/`.
+
+### 4. Register the MCP Server with Claude Code
+
+```bash
+claude mcp add agentic-bridge -- node ~/repos/agentic-workflow/mcp-bridge/dist/mcp.js
+```
+
+This registers the bridge as a stdio-based MCP server that Claude Code can invoke.
+
+## Environment Configuration
+
+Copy the example environment file and edit as needed:
+
+```bash
+cd ~/repos/agentic-workflow/mcp-bridge
+cp .env.example .env
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `3100` | Port for the Fastify REST API server |
+| `HOST` | `127.0.0.1` | Bind address (loopback only by default) |
+| `DB_PATH` | `./bridge.db` | Path to the SQLite database file |
+| `ALLOW_REMOTE` | unset | Set to `1` to allow binding to non-loopback addresses |
+
+The server refuses to bind to non-loopback addresses unless `ALLOW_REMOTE=1` is set, since it has no authentication layer.
+
+## Running the Servers
+
+### REST API Server (Fastify)
+
+```bash
+cd ~/repos/agentic-workflow/mcp-bridge
+
+# Development mode (tsx, auto-restarts not included -- use manually)
+npm run dev
+
+# Production mode (requires prior build)
+npm run build
+npm start
+```
+
+The REST API starts at `http://127.0.0.1:3100` by default. It exposes message and task routes for HTTP-based agent communication.
+
+### MCP Server (stdio)
+
+The MCP server runs as a stdio process, intended to be launched by Claude Code or Codex CLI:
+
+```bash
+# Direct invocation (for testing)
+cd ~/repos/agentic-workflow/mcp-bridge
+npm run build
+npm run mcp
+
+# Normal usage: Claude Code spawns it via the registered MCP config
+claude mcp add agentic-bridge -- node ~/repos/agentic-workflow/mcp-bridge/dist/mcp.js
+```
+
+The MCP server exposes five tools: `send_context`, `get_messages`, `get_unread`, `assign_task`, `report_status`.
+
+## Running Tests
+
+```bash
+cd ~/repos/agentic-workflow/mcp-bridge
+
+# Single run
+npm run test
+
+# Watch mode
+npm run test:watch
+
+# Type-check without emitting files
+npm run typecheck
+```
+
+Tests use in-memory SQLite -- no database file is created or modified during testing.
+
+## Building
+
+```bash
+cd ~/repos/agentic-workflow/mcp-bridge
+npm run build
+```
+
+Build configuration (from `tsconfig.json`):
+
+| Setting | Value |
+|---------|-------|
+| Target | ES2022 |
+| Module | Node16 |
+| Module Resolution | Node16 |
+| Output Directory | `dist/` |
+| Source Directory | `src/` |
+| Strict Mode | Enabled |
+| Source Maps | Enabled |
+| Declaration Files | Enabled |
+
+The build compiles `src/**/*` to `dist/`, excluding `node_modules`, `dist`, and `tests`.
+
+## Project Structure
+
+```
+agentic-workflow/
+├── skills/                    # Claude Code custom skills (symlinked to ~/.claude/skills/)
+│   ├── review/                # Multi-agent PR review
+│   ├── postReview/            # GitHub comment publisher
+│   ├── addressReview/         # Review fix implementer
+│   └── enhancePrompt/         # Context-aware prompt rewriter
+├── bootstrap/                 # Repo documentation generator skill
+├── config/                    # Settings & MCP config archive
+│   ├── settings.json
+│   └── mcp.json
+├── mcp-bridge/                # MCP bridge application
+│   ├── src/
+│   │   ├── application/       # AppResult<T>, services (never throw)
+│   │   ├── db/                # SQLite schema, client interface, transactions
+│   │   ├── transport/         # Typed router, Zod schemas, controllers
+│   │   ├── routes/            # Route factories
+│   │   ├── server.ts          # Fastify server factory
+│   │   ├── mcp.ts             # MCP stdio server entry point
+│   │   └── index.ts           # REST API entry point
+│   ├── tests/                 # Vitest test files
+│   ├── dist/                  # Compiled output (gitignored)
+│   ├── .env.example           # Environment variable template
+│   ├── package.json
+│   ├── tsconfig.json
+│   └── vitest.config.ts
+├── setup.sh                   # One-command setup script
+└── README.md
+```
+
+## Common Development Tasks
+
+### Adding a New Service
+
+1. Create the service function in `mcp-bridge/src/application/services/`.
+2. Return `AppResult<T>` -- never throw exceptions.
+3. Wire it into a route in `mcp-bridge/src/routes/` (for REST) and/or register a tool in `mcp-bridge/src/mcp.ts` (for MCP).
+4. Add tests in `mcp-bridge/tests/` using the `beforeEach` in-memory DB pattern.
+
+### Adding a New Skill
+
+1. Create a directory under `skills/` with the skill's name.
+2. Add the skill name to the `for` loop in `setup.sh` so it gets symlinked on setup.
+3. Re-run `./setup.sh` to install the symlink.

--- a/planning/PRODUCT_ROADMAP.md
+++ b/planning/PRODUCT_ROADMAP.md
@@ -1,0 +1,138 @@
+# Product Roadmap
+
+## v1.0 — Current Release
+
+### Scope
+
+The initial release provides three core capabilities:
+
+1. **Skills Archive** — Five Claude Code custom skills (`/review`, `/postReview`, `/addressReview`, `/enhancePrompt`, `/bootstrap`) version-controlled and installable via symlink. Configuration archive for `settings.json` and `mcp.json`.
+
+2. **Bootstrap Skill** — Repo documentation generator that detects which of 17 Pivot-pattern documents exist, generates missing ones adapted to the target repo's tech stack, and creates a `CLAUDE.md` if none exists.
+
+3. **MCP Bridge** — TypeScript MCP server for bidirectional multi-agent communication with five tools (`send_context`, `get_messages`, `get_unread`, `assign_task`, `report_status`). Dual transport: MCP stdio for Claude Code integration and Fastify REST API on port 3100. SQLite store-and-forward persistence with WAL mode.
+
+### Success Criteria
+
+- [x] One-command setup via `./setup.sh` that symlinks skills, copies config, and installs npm dependencies
+- [x] MCP server registers with Claude Code via `claude mcp add`
+- [x] REST API starts on loopback with safety check for non-loopback binding
+- [x] Full end-to-end type safety with `AppResult<T>` pattern (services never throw)
+- [x] Atomic transactions for multi-step operations (assign_task, report_status, get_unread)
+- [x] `/review` skill spawns parallel domain-specific reviewers and produces structured JSON output
+- [x] TypeScript strict mode, declaration maps, and source maps enabled
+
+### Timeline
+
+Delivered. Current state of the repository.
+
+---
+
+## v1.1 — Quality and Developer Experience
+
+### Scope
+
+Improvements identified from code review and gap analysis of the current implementation.
+
+**1. API Pagination**
+Add `limit` and `offset` query parameters to `get_messages`, `get_unread`, and `getTasksByConversation`. Conversations with high message volume currently return unbounded result sets. The SQLite queries already support `ORDER BY created_at ASC` — adding `LIMIT`/`OFFSET` clauses and returning a `{ data, total, hasMore }` envelope is straightforward.
+
+**2. Response Validation**
+The REST API validates inputs with Zod but does not validate outputs. Each `RouteSchema` already has a `response` field — wire it into `registerRoute` so that outbound payloads are parsed against the response schema in development mode (skip in production for performance). This catches schema drift between services and controllers.
+
+**3. ESLint and Prettier**
+No linter or formatter is currently configured. Add `eslint` with `@typescript-eslint/parser` and `prettier` with a shared config. Add `npm run lint` and `npm run format` scripts. Enforce consistent code style across contributions.
+
+**4. CI/CD Pipeline**
+No continuous integration exists. Add a GitHub Actions workflow that runs on pull requests:
+- `npm run typecheck` — TypeScript compilation check
+- `npm run lint` — ESLint
+- `npm run test` — Vitest
+- Build verification (`npm run build`)
+
+**5. Test Coverage Expansion**
+The current test suite exists but coverage of edge cases is unknown. Add tests for:
+- Transaction rollback on failure in `assign_task` and `report_status`
+- Concurrent message reads in `get_unread` (mark-as-read atomicity)
+- Zod validation error formatting in the REST API
+- MCP tool error responses
+
+**6. Error Logging and Observability**
+The Fastify logger is enabled but services do not log. Add structured logging to service functions for debugging multi-agent workflows — particularly useful when tracing message flow between agents.
+
+### Success Criteria
+
+- [ ] All list endpoints support pagination with `limit`/`offset` parameters
+- [ ] Response validation runs in development mode without performance impact in production
+- [ ] ESLint and Prettier pass with zero warnings on the entire codebase
+- [ ] CI pipeline runs on every PR and blocks merge on failure
+- [ ] Test coverage reaches 80%+ for application services
+- [ ] Structured logs trace message flow across conversations
+
+### Timeline
+
+Estimated 2-4 weeks of focused development. Each item is independent and can be delivered incrementally. Recommended order: ESLint/Prettier first (establishes standards for subsequent work), then CI/CD, then pagination, then response validation, then tests, then logging.
+
+---
+
+## v2.0 — Platform Expansion
+
+### Scope
+
+Extend from a bridge utility into a broader multi-agent development platform.
+
+**1. Additional MCP Tools**
+
+Expand the MCP tool surface beyond messaging and task management:
+
+- `list_conversations` — Return all conversation UUIDs with metadata (message count, last activity, participants). Currently, an agent must know a conversation UUID to interact with it.
+- `search_messages` — Full-text search across message payloads. Useful for agents reviewing historical context.
+- `delete_conversation` — Clean up completed workflows. Currently, data accumulates indefinitely in the SQLite database.
+- `get_task_tree` — Return tasks with their status reports as a nested structure, showing the full lifecycle of a task assignment.
+- `subscribe_updates` — Long-poll or SSE endpoint for real-time notification when new messages arrive for an agent, eliminating the need to poll `get_unread`.
+
+**2. Web Dashboard for Conversations**
+
+Build a lightweight web UI for observing multi-agent workflows:
+
+- Conversation timeline view showing messages between agents with sender/recipient labels
+- Task board view (kanban-style) showing tasks by status (pending, in_progress, completed, failed)
+- Live updates via SSE from the Fastify server
+- Read-only by default — no write operations from the UI to avoid interfering with agent workflows
+- Built with vanilla HTML/CSS/JS or a minimal framework (no heavy SPA framework) to keep the dependency footprint small
+
+Technology considerations: Since the REST API already exists, the dashboard is a static frontend that consumes the existing endpoints. Could be served from Fastify as static files or run separately.
+
+**3. Multi-Model Support**
+
+The current implementation is model-agnostic at the protocol level (MCP and REST are not Claude-specific), but the skills and documentation assume Claude Code and Codex. Extend support to:
+
+- **OpenAI Codex** — Already partially supported via the MCP bridge. Document the integration pattern.
+- **Gemini CLI** — If/when Google ships MCP support, add configuration templates.
+- **Local models (Ollama, LM Studio)** — Document how to connect local models as agents via the REST API.
+- **Agent identity registry** — Formalize agent identifiers beyond free-form strings. Add an `agents` table tracking registered agents with capabilities, model type, and availability status.
+
+**4. Skill Marketplace Integration**
+
+The setup script references plugin marketplaces (`claude-plugins-official`, `voltagent-subagents`, `compound-engineering-plugin`). Build deeper integration:
+
+- Skill discovery and installation from community repositories
+- Skill versioning and update mechanism
+- Dependency declaration between skills (e.g., `/addressReview` depends on `/review`)
+
+### Success Criteria
+
+- [ ] At least 3 new MCP tools shipped and documented
+- [ ] Web dashboard displays live conversation data from the bridge
+- [ ] At least one non-Claude agent successfully communicates through the bridge
+- [ ] Agent identity registry replaces free-form sender/recipient strings
+- [ ] Skill installation supports remote repositories beyond local symlinks
+
+### Timeline
+
+Estimated 2-3 months. This is a significant scope expansion and should be broken into sub-releases:
+
+- v2.0-alpha: Additional MCP tools + conversation listing (2-3 weeks)
+- v2.0-beta: Web dashboard MVP with conversation timeline (3-4 weeks)
+- v2.0-rc: Multi-model documentation and agent registry (2-3 weeks)
+- v2.0: Skill marketplace integration and polish (2-3 weeks)

--- a/planning/PR_GUIDE.md
+++ b/planning/PR_GUIDE.md
@@ -1,0 +1,101 @@
+# Pull Request Review Guide
+
+Use this checklist when opening or reviewing pull requests. Every item applies unless explicitly noted otherwise.
+
+---
+
+## Type Safety
+
+- [ ] **Strict mode passes** -- `tsc --noEmit` completes without errors.
+- [ ] **No `any` usage** -- use `unknown` with runtime narrowing, or define a proper type.
+- [ ] **`import type` used correctly** -- symbols used only in type position use `import type`.
+- [ ] **`.js` extension on all imports** -- required by Node16 ESM module resolution.
+- [ ] **Zod schemas have companion type aliases** -- every `FooSchema` has a corresponding `type Foo = z.infer<typeof FooSchema>`.
+- [ ] **Route schemas use the dual declaration pattern** -- both `const` value and `type` alias with the same name:
+  ```ts
+  export const GetMessagesSchema = { params: ..., response: ... } as const;
+  export type GetMessagesSchema = typeof GetMessagesSchema;
+  ```
+- [ ] **`defineRoute()` used for all route registrations** -- captures `TSchema` at compile time for end-to-end type safety between schema and handler.
+
+---
+
+## Error Handling
+
+- [ ] **Services return `AppResult<T>`** -- no service function throws. Use `ok()` and `err()` from `application/result.ts`.
+- [ ] **Error codes use `ERROR_CODE` constants** -- never hardcode strings like `"NOT_FOUND"`. Use `ERROR_CODE.notFound`.
+- [ ] **Controllers use `appErr()` for error translation** -- converts `AppError` to `ApiResponse` error shape:
+  ```ts
+  if (!result.ok) return appErr(result.error);
+  ```
+- [ ] **`statusHint` is set on errors** -- every `err()` call includes an appropriate HTTP status hint (404, 409, etc.).
+- [ ] **Preconditions checked before writes** -- validate existence (e.g., `db.getTask()`) before inserting or updating rows to prevent orphaned records.
+- [ ] **No uncaught exceptions leak** -- the server catches `ZodError` (400) and unknown errors (500). Services must not rely on the server catch for expected failure modes.
+
+---
+
+## Database
+
+- [ ] **Multi-write operations use `db.transaction()`** -- any service that calls more than one write method wraps them in a transaction for atomicity:
+  ```ts
+  const result = db.transaction(() => {
+    const task = db.insertTask(/* ... */);
+    db.insertMessage(/* ... */);
+    return task;
+  });
+  ```
+- [ ] **Read-then-write sequences are atomic** -- operations like "fetch unread then mark all read" must be wrapped in a transaction to prevent races.
+- [ ] **Row types are accurate** -- `MessageRow` and `TaskRow` interfaces match the actual SQL schema in `db/schema.ts`. New columns require updates to both.
+- [ ] **Prepared statements used for repeated queries** -- add statements to the `stmts` object in `createDbClient()` rather than calling `db.prepare()` inline.
+- [ ] **Indexes exist for new query patterns** -- if a new query filters on a column, add an index in `MIGRATIONS`.
+- [ ] **Nullable fields use `?? null`** -- optional service input fields are coalesced to `null` before passing to the database layer:
+  ```ts
+  meta_prompt: input.meta_prompt ?? null,
+  ```
+
+---
+
+## Testing
+
+- [ ] **Tests exist for new services** -- every new service function has at least one success-path and one error-path test.
+- [ ] **In-memory SQLite used** -- tests use `new Database(":memory:")` per `beforeEach`, never a file-based database.
+- [ ] **Migrations applied in test setup** -- `raw.exec(MIGRATIONS)` runs before creating the client.
+- [ ] **`randomUUID()` for isolation** -- each test uses unique conversation/entity IDs to prevent cross-test interference.
+- [ ] **Discriminated union narrowing in assertions** -- always check `result.ok` and early-return before accessing `.data` or `.error`:
+  ```ts
+  expect(result.ok).toBe(true);
+  if (!result.ok) return;
+  expect(result.data.id).toBeDefined();
+  ```
+- [ ] **Atomicity verified on failure** -- when testing error paths, verify that no partial writes occurred (e.g., no orphaned messages when a task lookup fails).
+- [ ] **Tests run with `vitest run`** -- all tests pass before PR submission.
+
+---
+
+## API Design
+
+- [ ] **Zod validation on all inputs** -- every route schema defines `body`, `params`, and/or `querystring` with Zod schemas. The server validates automatically; handlers never call `.parse()`.
+- [ ] **UUID fields validated with `z.string().uuid()`** -- all ID and conversation fields use UUID validation, not bare `z.string()`.
+- [ ] **String fields validated with `z.string().min(1)`** -- required string fields reject empty strings.
+- [ ] **Response schemas defined** -- every route schema includes a `response` Zod schema for documentation and potential response validation.
+- [ ] **Correct HTTP status codes** -- POST handlers return 201 on success (handled by `server.ts`), GET returns 200. Error `statusHint` maps to appropriate codes.
+
+---
+
+## Security
+
+- [ ] **Server binds to loopback by default** -- `127.0.0.1` unless `ALLOW_REMOTE=1` is set. New entry points must respect this constraint.
+- [ ] **No secrets in code or config** -- `.env` files are in `.gitignore`. Environment variables used for `PORT`, `HOST`, `DB_PATH`.
+- [ ] **No sensitive data in error details** -- `AppError.details` must not expose internal state, stack traces, or database internals.
+- [ ] **SQL injection prevention** -- all queries use parameterized prepared statements (named `@param` syntax in better-sqlite3). Never interpolate user input into SQL strings.
+- [ ] **Input size limits considered** -- large text fields (`payload`, `details`) should have reasonable Zod `.max()` limits if the endpoint is exposed beyond local use.
+
+---
+
+## Documentation & Style
+
+- [ ] **Section comment headers used** -- files with multiple logical sections use the `// ── Section ──────` format.
+- [ ] **JSDoc on exported interfaces and functions** -- at minimum, public interfaces and factory functions have `/** */` descriptions.
+- [ ] **File naming is kebab-case** -- new files follow `send-context.ts`, `message-schemas.ts` pattern.
+- [ ] **No dead code** -- unused imports, variables, or functions are removed.
+- [ ] **Consistent `as const` on schema objects** -- route schema objects use `as const` for literal type inference.

--- a/planning/TESTING.md
+++ b/planning/TESTING.md
@@ -1,0 +1,207 @@
+# Testing Strategy
+
+## Overview
+
+All tests run against **in-memory SQLite** databases. Each test gets a fresh database instance via `beforeEach`, so tests are fully isolated, deterministic, and fast -- no filesystem cleanup or shared state.
+
+The test suite uses **Vitest** with explicit imports (globals are disabled in the config).
+
+## Test Location
+
+```
+mcp-bridge/
+  tests/
+    services.test.ts    # Service-layer unit tests
+  vitest.config.ts      # Vitest configuration
+```
+
+Tests live in `mcp-bridge/tests/`. The `tsconfig.json` excludes `tests/` from compilation output, but Vitest picks them up at runtime via `tsx`.
+
+## Running Tests
+
+```bash
+cd mcp-bridge
+
+# Single run (CI-friendly)
+npm run test
+
+# Watch mode (re-runs on file changes)
+npm run test:watch
+
+# Type-check only (no emit)
+npm run typecheck
+```
+
+Under the hood:
+- `npm run test` runs `vitest run` (single pass, exits with code 0/1)
+- `npm run test:watch` runs `vitest` (interactive watch mode)
+- `npm run typecheck` runs `tsc --noEmit` (validates types without producing output)
+
+## Test Configuration
+
+From `vitest.config.ts`:
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: false,
+    testTimeout: 10_000,
+  },
+});
+```
+
+- **`globals: false`** -- All Vitest functions (`describe`, `it`, `expect`, `beforeEach`) must be explicitly imported.
+- **`testTimeout: 10_000`** -- 10-second timeout per test (generous for in-memory SQLite operations).
+
+## Test Patterns
+
+### Fresh Database per Test
+
+Every test starts with a clean in-memory SQLite database. The `beforeEach` hook creates the database, runs migrations, and wraps it in the `DbClient` interface:
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { createDbClient, type DbClient } from "../src/db/client.js";
+import { MIGRATIONS } from "../src/db/schema.js";
+
+let db: DbClient;
+
+beforeEach(() => {
+  const raw = new Database(":memory:");
+  raw.pragma("journal_mode = WAL");
+  raw.exec(MIGRATIONS);
+  db = createDbClient(raw);
+});
+```
+
+This pattern ensures:
+- No test pollution -- each test has its own tables with zero rows.
+- No disk I/O -- `:memory:` databases are purely in-RAM.
+- Real schema -- the same `MIGRATIONS` SQL that runs in production creates the tables.
+
+### AppResult Assertion Pattern
+
+All service functions return `AppResult<T>`, a discriminated union:
+
+```ts
+type AppResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: { code: string; message: string } }
+```
+
+Tests assert on the `ok` flag first, then narrow the type with a guard before accessing `data` or `error`:
+
+```ts
+it("inserts a message and returns it", () => {
+  const conv = randomUUID();
+  const result = sendContext(db, {
+    conversation: conv,
+    sender: "claude-code",
+    recipient: "codex",
+    payload: "Hello from Claude",
+    meta_prompt: "Analyze this codebase",
+  });
+
+  expect(result.ok).toBe(true);
+  if (!result.ok) return;          // Type narrowing guard
+  expect(result.data.conversation).toBe(conv);
+  expect(result.data.sender).toBe("claude-code");
+  expect(result.data.kind).toBe("context");
+  expect(result.data.read_at).toBeNull();
+});
+```
+
+For error cases, the same pattern is inverted:
+
+```ts
+it("returns error for unknown task_id without inserting a message", () => {
+  const result = reportStatus(db, {
+    conversation: conv,
+    sender: "codex",
+    recipient: "claude-code",
+    task_id: randomUUID(),
+    status: "completed",
+    payload: "Done",
+  });
+
+  expect(result.ok).toBe(false);
+  if (result.ok) return;           // Type narrowing guard
+  expect(result.error.code).toBe("NOT_FOUND");
+});
+```
+
+### Conversation Isolation via randomUUID
+
+Each test generates its own conversation UUID with `randomUUID()`, so even if tests share a database (they don't due to `beforeEach`), data would not collide:
+
+```ts
+const conv = randomUUID();
+```
+
+### Verifying Side Effects
+
+Tests that touch multiple tables verify both the primary return value and side effects. For example, `assignTask` creates both a task record and a conversation message:
+
+```ts
+it("creates a task and a conversation message atomically", () => {
+  const conv = randomUUID();
+  const result = assignTask(db, {
+    conversation: conv,
+    domain: "backend",
+    summary: "Fix auth bug",
+    details: "JWT validation is missing",
+    assigned_to: "codex",
+  });
+
+  expect(result.ok).toBe(true);
+  if (!result.ok) return;
+  expect(result.data.domain).toBe("backend");
+  expect(result.data.status).toBe("pending");
+
+  // Check that a message was also created
+  const msgs = getMessagesByConversation(db, conv);
+  expect(msgs.ok).toBe(true);
+  if (!msgs.ok) return;
+  expect(msgs.data).toHaveLength(1);
+  expect(msgs.data[0].kind).toBe("task");
+});
+```
+
+For error cases, tests verify that no orphaned records were created (transactional integrity):
+
+```ts
+// Verify no orphaned message was created
+const msgs = getMessagesByConversation(db, conv);
+expect(msgs.ok).toBe(true);
+if (!msgs.ok) return;
+expect(msgs.data).toHaveLength(0);
+```
+
+## Coverage Targets
+
+The current test suite covers the service layer (`src/application/services/`):
+
+| Service | Tested |
+|---------|--------|
+| `sendContext` | Insert + return shape |
+| `getMessagesByConversation` | Chronological order, empty conversation |
+| `getUnreadMessages` | Returns unread, marks as read, subsequent call returns empty |
+| `assignTask` | Task creation + message side effect |
+| `reportStatus` | Status update + task mutation, error on missing task |
+
+Coverage targets to aim for:
+- **Service layer**: 100% of exported functions should have happy-path and error-path tests.
+- **Transport/route layer**: Integration tests against Fastify's `inject()` method (not yet implemented).
+- **MCP tool layer**: Validate Zod schemas reject malformed input (not yet implemented).
+
+## Writing New Tests
+
+1. Add test files to `mcp-bridge/tests/` with the `.test.ts` suffix.
+2. Import from `vitest` explicitly (globals are off).
+3. Use the `beforeEach` pattern above for database setup.
+4. Return `AppResult<T>` from all service functions -- never throw.
+5. Use `randomUUID()` for conversation/task IDs.
+6. Assert `result.ok` first, then narrow with a guard before accessing `.data` or `.error`.


### PR DESCRIPTION
## Summary

- Adds 13 Pivot-pattern planning documents to `planning/` covering architecture, API contracts, code style, testing, deployment, ERD, dependency graph, commit strategy, PR guide, local dev, business plan, product roadmap, and competitive analysis
- Adds `CLAUDE.md` with tech stack, key patterns (AppResult, typed router, transactions), code style rules, commands reference, and merge gate
- Generated using the `/bootstrap` skill against the repo itself

## Documents Added

| Document | Content |
|----------|---------|
| `CLAUDE.md` | Project preamble for Claude Code |
| `planning/ARCHITECTURE.md` | System components and data flow |
| `planning/API_CONTRACT.md` | MCP bridge REST & MCP tool schemas |
| `planning/ERD.md` | SQLite schema and relationships |
| `planning/CODE_STYLE.md` | TypeScript conventions |
| `planning/COMMIT_STRATEGY.md` | Commit message format |
| `planning/PR_GUIDE.md` | PR workflow and review process |
| `planning/TESTING.md` | Test strategy and coverage |
| `planning/LOCAL_DEV.md` | Local development setup |
| `planning/DEPLOYMENT.md` | Deployment procedures |
| `planning/DEPENDENCY_GRAPH.md` | Module dependency map |
| `planning/BUSINESS_PLAN.md` | Project strategy |
| `planning/PRODUCT_ROADMAP.md` | Feature roadmap |
| `planning/COMPETITIVE_ANALYSIS.md` | Landscape analysis |

## Test plan

- [x] All docs render correctly in GitHub markdown preview
- [x] `CLAUDE.md` references correct file paths and commands
- [ ] Verify no sensitive information in generated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)