### PR TITLE
feat: integrate prism-mcp session context and dark factory into all skills

### DIFF
--- a/bootstrap/SKILL.md
+++ b/bootstrap/SKILL.md
@@ -107,11 +107,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -119,22 +117,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/_preamble.md
+++ b/skills/_preamble.md
@@ -107,11 +107,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -119,21 +117,48 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->

--- a/skills/addressReview/SKILL.md
+++ b/skills/addressReview/SKILL.md
@@ -107,11 +107,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -119,22 +117,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/archReview/SKILL.md
+++ b/skills/archReview/SKILL.md
@@ -111,11 +111,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -123,22 +121,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 
@@ -267,6 +292,25 @@ For **each component boundary** identified in Step 3, analyze these four failure
 - Can state from one request/user leak into another?
 - Are there shared mutable globals?
 - Is cleanup guaranteed (connections, file handles, temp files)?
+
+## Step 5.5: Dark Factory Adversarial Stress Test (if enabled)
+
+**Start the pipeline:**
+```
+mcp__prism-mcp__session_start_pipeline — project: REPO_SLUG,
+  objective: "Adversarially challenge this architecture review of: {target description from Step 1}. Find: (1) failure modes not identified in the edge case analysis, (2) risks whose impact or likelihood is understated, (3) suggested improvements that are vague or insufficient ('add monitoring' is not a mitigation — what specifically?), (4) component boundaries where error propagation is unaddressed. For each finding, provide component:function or file:line evidence.",
+  working_directory: "<absolute path to repo root>",
+  max_iterations: 2
+```
+
+Store the returned `pipeline_id`. Poll until complete:
+```
+mcp__prism-mcp__session_check_pipeline_status — pipeline_id: <pipeline_id>
+```
+
+When complete:
+- `COMPLETED` — no additional issues found beyond what the review already covers. Proceed to Step 6.
+- `FAILED` — incorporate the evaluator's additional findings into the edge case analysis before writing the verdict. Surface them clearly in the Top Risks table.
 
 ## Step 6: Review Verdict
 

--- a/skills/bugHunt/SKILL.md
+++ b/skills/bugHunt/SKILL.md
@@ -111,11 +111,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -123,22 +121,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 
@@ -173,6 +198,30 @@ Find the bug in the source code.
 1. Use Grep and Glob to search for code related to the failure — error messages, function names from stack traces, relevant module paths.
 2. Use Agent to explore the codebase if the initial search is insufficient.
 3. Read all relevant source files. Trace the logic to identify the defect.
+
+## Step 3.5: Dark Factory Fix Pipeline (if enabled)
+
+**Build the objective** from what you learned in Steps 2–3 — be specific about the root cause and the failing test command.
+
+**Start the pipeline:**
+```
+mcp__prism-mcp__session_start_pipeline — project: REPO_SLUG,
+  objective: "Fix the bug: <one-sentence description>. Root cause: <root cause from Step 3>. Reproduce with: <test command from Step 2>. The fix must: (1) make the failing test pass, (2) introduce no new test failures, (3) be minimal — only the identified defect is changed, (4) include a regression test for the specific edge case.",
+  working_directory: "<absolute path to repo root>",
+  max_iterations: 3
+```
+
+Store the returned `pipeline_id`.
+
+**Poll until complete (check every 15s):**
+```
+mcp__prism-mcp__session_check_pipeline_status — pipeline_id: <pipeline_id>
+```
+
+Continue polling while `status` is `PENDING` or `RUNNING`. When `status` is:
+- `COMPLETED` — pipeline succeeded. Read the fix summary from the pipeline output, then skip to Step 8 (Write QA Report) with status `fixed`.
+- `FAILED` — pipeline exhausted iterations. Fall through to manual Step 4, using the evaluator's final critique as additional context for your fix attempt.
+- `ABORTED` — skip to Step 8 with status `unfixed`.
 
 ## Step 4: Fix
 

--- a/skills/bugReport/SKILL.md
+++ b/skills/bugReport/SKILL.md
@@ -111,11 +111,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -123,22 +121,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/design-analyze-ios/SKILL.md
+++ b/skills/design-analyze-ios/SKILL.md
@@ -107,11 +107,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -119,22 +117,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/design-analyze-web/SKILL.md
+++ b/skills/design-analyze-web/SKILL.md
@@ -107,11 +107,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -119,22 +117,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/design-analyze/SKILL.md
+++ b/skills/design-analyze/SKILL.md
@@ -107,6 +107,60 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
+## Session Context
+
+Load prior work state for this repo from prism-mcp before starting.
+
+**1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
+- `/officeHours add dark mode` → `"dark mode UI feature"`
+- `/rootCause TypeError cannot read properties` → `"TypeError cannot read properties"`
+- `/review 42` → use the PR title once fetched: `"PR {title} review"`
+- No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
+
+**2. Load context from prism-mcp:**
+```
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
+```
+
+Store the returned `expected_version` — you will need it at Session Close.
+
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
+  Use this to inform your approach before continuing.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
+
 <!-- === PREAMBLE END === -->
 
 > **Note:** This skill creates design context — missing `design-tokens.json` is expected on first run.

--- a/skills/design-evolve-ios/SKILL.md
+++ b/skills/design-evolve-ios/SKILL.md
@@ -107,11 +107,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -119,22 +117,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/design-evolve-web/SKILL.md
+++ b/skills/design-evolve-web/SKILL.md
@@ -107,11 +107,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -119,22 +117,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/design-evolve/SKILL.md
+++ b/skills/design-evolve/SKILL.md
@@ -107,6 +107,60 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
+## Session Context
+
+Load prior work state for this repo from prism-mcp before starting.
+
+**1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
+- `/officeHours add dark mode` → `"dark mode UI feature"`
+- `/rootCause TypeError cannot read properties` → `"TypeError cannot read properties"`
+- `/review 42` → use the PR title once fetched: `"PR {title} review"`
+- No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
+
+**2. Load context from prism-mcp:**
+```
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
+```
+
+Store the returned `expected_version` — you will need it at Session Close.
+
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
+  Use this to inform your approach before continuing.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
+
 <!-- === PREAMBLE END === -->
 
 <!-- === DESIGN PREAMBLE START === -->

--- a/skills/design-implement-ios/SKILL.md
+++ b/skills/design-implement-ios/SKILL.md
@@ -106,11 +106,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -118,22 +116,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 
@@ -320,6 +345,25 @@ Using the mockup as visual reference and `Theme.*` values:
 - Use `.foregroundColor(Theme.Colors.textPrimary)` not hardcoded color values
 
 Reference `.impeccable.md` (if present) for brand personality — spacing density, interaction patterns.
+
+## Step 3.5: Dark Factory Token Compliance Evaluation (if enabled)
+
+**Start the pipeline:**
+```
+mcp__prism-mcp__session_start_pipeline — project: REPO_SLUG,
+  objective: "Audit the generated SwiftUI components for Theme.swift compliance. Check: (1) no hardcoded Color(hex:) calls in any view file (only Theme.swift may define them), (2) no hardcoded CGFloat literals for spacing that correspond to a Theme.Spacing token, (3) no hardcoded Font.system(size:) calls in any view file (only Theme.swift may define them), (4) all color uses reference Theme.Colors.*, spacing uses reference Theme.Spacing.*, font uses reference Theme.Typography.*. For each violation, provide file:line evidence.",
+  working_directory: "<absolute path to repo root>",
+  max_iterations: 2
+```
+
+Store the returned `pipeline_id`. Poll until complete:
+```
+mcp__prism-mcp__session_check_pipeline_status — pipeline_id: <pipeline_id>
+```
+
+When complete:
+- `COMPLETED` — no Theme.swift violations found. Proceed to Step 4.
+- `FAILED` — fix the specific violations identified with `file:line` evidence, then re-run the pipeline once before proceeding.
 
 ## Step 4: Validate
 

--- a/skills/design-implement-web/SKILL.md
+++ b/skills/design-implement-web/SKILL.md
@@ -106,11 +106,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -118,22 +116,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 
@@ -288,6 +313,25 @@ Using the mockup as visual reference and the generated token files:
 - Include responsive breakpoints matching the mockup
 
 Reference `.impeccable.md` for design personality — spacing density, animation approach, interaction patterns.
+
+## Step 3.5: Dark Factory Token Compliance Evaluation (if enabled)
+
+**Start the pipeline:**
+```
+mcp__prism-mcp__session_start_pipeline — project: REPO_SLUG,
+  objective: "Audit the generated web components for design token compliance. Check: (1) no hardcoded color values (hex, rgb, hsl, named CSS colors) in any generated component file, (2) no hardcoded spacing values (px, rem, em) that correspond to a token defined in tokens.css, (3) all interactive elements have a defined :focus and :hover state using token values, (4) no Tailwind arbitrary values (e.g. w-[347px]) that correspond to a design token. For each violation, provide file:line evidence.",
+  working_directory: "<absolute path to repo root>",
+  max_iterations: 2
+```
+
+Store the returned `pipeline_id`. Poll until complete:
+```
+mcp__prism-mcp__session_check_pipeline_status — pipeline_id: <pipeline_id>
+```
+
+When complete:
+- `COMPLETED` — no token violations found. Proceed to Step 4.
+- `FAILED` — fix the specific violations identified with `file:line` evidence, then re-run the pipeline once before proceeding.
 
 ## Step 4: Validate
 

--- a/skills/design-implement/SKILL.md
+++ b/skills/design-implement/SKILL.md
@@ -107,6 +107,60 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
+## Session Context
+
+Load prior work state for this repo from prism-mcp before starting.
+
+**1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
+- `/officeHours add dark mode` → `"dark mode UI feature"`
+- `/rootCause TypeError cannot read properties` → `"TypeError cannot read properties"`
+- `/review 42` → use the PR title once fetched: `"PR {title} review"`
+- No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
+
+**2. Load context from prism-mcp:**
+```
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
+```
+
+Store the returned `expected_version` — you will need it at Session Close.
+
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
+  Use this to inform your approach before continuing.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
+
 <!-- === PREAMBLE END === -->
 
 <!-- === DESIGN PREAMBLE START === -->

--- a/skills/design-language/SKILL.md
+++ b/skills/design-language/SKILL.md
@@ -107,11 +107,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -119,22 +117,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/design-mockup-ios/SKILL.md
+++ b/skills/design-mockup-ios/SKILL.md
@@ -106,11 +106,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -118,22 +116,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/design-mockup-web/SKILL.md
+++ b/skills/design-mockup-web/SKILL.md
@@ -107,11 +107,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -119,22 +117,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/design-mockup/SKILL.md
+++ b/skills/design-mockup/SKILL.md
@@ -107,6 +107,60 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
+## Session Context
+
+Load prior work state for this repo from prism-mcp before starting.
+
+**1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
+- `/officeHours add dark mode` → `"dark mode UI feature"`
+- `/rootCause TypeError cannot read properties` → `"TypeError cannot read properties"`
+- `/review 42` → use the PR title once fetched: `"PR {title} review"`
+- No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
+
+**2. Load context from prism-mcp:**
+```
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
+```
+
+Store the returned `expected_version` — you will need it at Session Close.
+
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
+  Use this to inform your approach before continuing.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
+
 <!-- === PREAMBLE END === -->
 
 <!-- === DESIGN PREAMBLE START === -->

--- a/skills/design-refine/SKILL.md
+++ b/skills/design-refine/SKILL.md
@@ -108,6 +108,60 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
+## Session Context
+
+Load prior work state for this repo from prism-mcp before starting.
+
+**1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
+- `/officeHours add dark mode` → `"dark mode UI feature"`
+- `/rootCause TypeError cannot read properties` → `"TypeError cannot read properties"`
+- `/review 42` → use the PR title once fetched: `"PR {title} review"`
+- No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
+
+**2. Load context from prism-mcp:**
+```
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
+```
+
+Store the returned `expected_version` — you will need it at Session Close.
+
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
+  Use this to inform your approach before continuing.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
+
 <!-- === PREAMBLE END === -->
 
 <!-- === DESIGN PREAMBLE START === -->

--- a/skills/design-verify-ios/SKILL.md
+++ b/skills/design-verify-ios/SKILL.md
@@ -108,6 +108,60 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
+## Session Context
+
+Load prior work state for this repo from prism-mcp before starting.
+
+**1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
+- `/officeHours add dark mode` → `"dark mode UI feature"`
+- `/rootCause TypeError cannot read properties` → `"TypeError cannot read properties"`
+- `/review 42` → use the PR title once fetched: `"PR {title} review"`
+- No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
+
+**2. Load context from prism-mcp:**
+```
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
+```
+
+Store the returned `expected_version` — you will need it at Session Close.
+
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
+  Use this to inform your approach before continuing.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
+
 <!-- === PREAMBLE END === -->
 
 <!-- === DESIGN PREAMBLE START === -->

--- a/skills/design-verify-web/SKILL.md
+++ b/skills/design-verify-web/SKILL.md
@@ -108,6 +108,60 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
+## Session Context
+
+Load prior work state for this repo from prism-mcp before starting.
+
+**1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
+- `/officeHours add dark mode` → `"dark mode UI feature"`
+- `/rootCause TypeError cannot read properties` → `"TypeError cannot read properties"`
+- `/review 42` → use the PR title once fetched: `"PR {title} review"`
+- No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
+
+**2. Load context from prism-mcp:**
+```
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
+```
+
+Store the returned `expected_version` — you will need it at Session Close.
+
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
+  Use this to inform your approach before continuing.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
+
 <!-- === PREAMBLE END === -->
 
 <!-- === DESIGN PREAMBLE START === -->

--- a/skills/design-verify/SKILL.md
+++ b/skills/design-verify/SKILL.md
@@ -107,6 +107,60 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
+## Session Context
+
+Load prior work state for this repo from prism-mcp before starting.
+
+**1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
+- `/officeHours add dark mode` → `"dark mode UI feature"`
+- `/rootCause TypeError cannot read properties` → `"TypeError cannot read properties"`
+- `/review 42` → use the PR title once fetched: `"PR {title} review"`
+- No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
+
+**2. Load context from prism-mcp:**
+```
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
+```
+
+Store the returned `expected_version` — you will need it at Session Close.
+
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
+  Use this to inform your approach before continuing.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
+
 <!-- === PREAMBLE END === -->
 
 <!-- === DESIGN PREAMBLE START === -->

--- a/skills/enhancePrompt/SKILL.md
+++ b/skills/enhancePrompt/SKILL.md
@@ -107,11 +107,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -119,22 +117,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/officeHours/SKILL.md
+++ b/skills/officeHours/SKILL.md
@@ -26,7 +26,7 @@ Runs a structured brainstorming session and produces four domain-owned outputs �
 > | `/shipRelease` | Sync, test, push, open PR |
 > | `/syncDocs` | Post-ship doc updater |
 > | `/weeklyRetro` | Weekly retrospective with shipping streaks |
-> | `/officeHours` | Spec-driven brainstorming → product + engineering + design-brief + tasks |
+> | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
@@ -111,11 +111,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -123,22 +121,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 
@@ -677,6 +702,27 @@ Task guidelines:
 - Each task has `owner` (assigned name or "unassigned") and `status` (todo/in-progress/blocked/done)
 - Each task should be atomic — one logical unit of work
 - Task descriptions use "What/Why/Definition of Done/Reference" structure — NO implementation details in task body (those live in domain docs)
+
+## Step 6.5: Dark Factory Spec Validation (if enabled)
+
+**Start the pipeline** with the objective of finding criterion failures across the four docs:
+```
+mcp__prism-mcp__session_start_pipeline — project: REPO_SLUG,
+  objective: "Adversarially evaluate these four spec docs for the '{feature}' feature. Check: (1) product.md contains no technical implementation details, (2) engineering.md contains no user personas or business metrics, (3) design-brief.md contains no technical constraints, (4) TASKS.md references domain docs rather than duplicating implementation details, (5) all selected EARS requirement types are present with at least 2 requirements each, (6) every product.md requirement traces to at least one acceptance criterion, (7) TASKS.md dependency graph is topologically sorted with no circular dependencies. For each failing criterion, provide file:line evidence.",
+  working_directory: "<absolute path to plan output dir: ~/.agentic-workflow/$REPO_SLUG/plans/{timestamp}-{slug}/>",
+  max_iterations: 2
+```
+
+Store the returned `pipeline_id`. Poll until complete:
+```
+mcp__prism-mcp__session_check_pipeline_status — pipeline_id: <pipeline_id>
+```
+
+When complete:
+- `COMPLETED` — docs passed adversarial evaluation. Show: `Spec validated ✓` then proceed to Step 7.
+- `FAILED` — surface the evaluator's findings with the specific criterion failures and `file:line` evidence. Ask the user:
+  > "The adversarial evaluator flagged these issues: {findings}. Fix them before writing? (yes/no)"
+  If yes: regenerate the flagged sections and re-run the pipeline once. If no: proceed to Step 7 anyway and note the issues in the report.
 
 ## Step 7: Write the Output Directory
 

--- a/skills/postReview/SKILL.md
+++ b/skills/postReview/SKILL.md
@@ -108,6 +108,60 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
+## Session Context
+
+Load prior work state for this repo from prism-mcp before starting.
+
+**1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
+- `/officeHours add dark mode` → `"dark mode UI feature"`
+- `/rootCause TypeError cannot read properties` → `"TypeError cannot read properties"`
+- `/review 42` → use the PR title once fetched: `"PR {title} review"`
+- No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
+
+**2. Load context from prism-mcp:**
+```
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
+```
+
+Store the returned `expected_version` — you will need it at Session Close.
+
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
+  Use this to inform your approach before continuing.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
+
 <!-- === PREAMBLE END === -->
 
 # Post Review to GitHub

--- a/skills/productReview/SKILL.md
+++ b/skills/productReview/SKILL.md
@@ -111,11 +111,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -123,22 +121,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -107,11 +107,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -119,22 +117,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/rootCause/SKILL.md
+++ b/skills/rootCause/SKILL.md
@@ -111,11 +111,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -123,22 +121,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/shipRelease/SKILL.md
+++ b/skills/shipRelease/SKILL.md
@@ -112,6 +112,60 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
+## Session Context
+
+Load prior work state for this repo from prism-mcp before starting.
+
+**1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
+- `/officeHours add dark mode` → `"dark mode UI feature"`
+- `/rootCause TypeError cannot read properties` → `"TypeError cannot read properties"`
+- `/review 42` → use the PR title once fetched: `"PR {title} review"`
+- No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
+
+**2. Load context from prism-mcp:**
+```
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
+```
+
+Store the returned `expected_version` — you will need it at Session Close.
+
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
+  Use this to inform your approach before continuing.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
+
 <!-- === PREAMBLE END === -->
 
 ## Step 1: Pre-flight Checks

--- a/skills/syncDocs/SKILL.md
+++ b/skills/syncDocs/SKILL.md
@@ -112,6 +112,60 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
+## Session Context
+
+Load prior work state for this repo from prism-mcp before starting.
+
+**1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
+- `/officeHours add dark mode` → `"dark mode UI feature"`
+- `/rootCause TypeError cannot read properties` → `"TypeError cannot read properties"`
+- `/review 42` → use the PR title once fetched: `"PR {title} review"`
+- No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
+
+**2. Load context from prism-mcp:**
+```
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
+```
+
+Store the returned `expected_version` — you will need it at Session Close.
+
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
+  Use this to inform your approach before continuing.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
+
 <!-- === PREAMBLE END === -->
 
 ## Step 1: Parse Scope

--- a/skills/verify-app/SKILL.md
+++ b/skills/verify-app/SKILL.md
@@ -107,6 +107,60 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
+## Session Context
+
+Load prior work state for this repo from prism-mcp before starting.
+
+**1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
+- `/officeHours add dark mode` → `"dark mode UI feature"`
+- `/rootCause TypeError cannot read properties` → `"TypeError cannot read properties"`
+- `/review 42` → use the PR title once fetched: `"PR {title} review"`
+- No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
+
+**2. Load context from prism-mcp:**
+```
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
+```
+
+Store the returned `expected_version` — you will need it at Session Close.
+
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
+  Use this to inform your approach before continuing.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
+
 <!-- === PREAMBLE END === -->
 
 ---

--- a/skills/verify-ios/SKILL.md
+++ b/skills/verify-ios/SKILL.md
@@ -107,11 +107,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -119,22 +117,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/verify-web/SKILL.md
+++ b/skills/verify-web/SKILL.md
@@ -107,11 +107,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -119,22 +117,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 

--- a/skills/weeklyRetro/SKILL.md
+++ b/skills/weeklyRetro/SKILL.md
@@ -111,11 +111,9 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
-## Memory Recall
+## Session Context
 
-> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
-
-Check for prior discussion context in memory before reading the codebase.
+Load prior work state for this repo from prism-mcp before starting.
 
 **1. Derive a topic string** — synthesize 3–5 words from the skill argument and task intent:
 - `/officeHours add dark mode` → `"dark mode UI feature"`
@@ -123,22 +121,49 @@ Check for prior discussion context in memory before reading the codebase.
 - `/review 42` → use the PR title once fetched: `"PR {title} review"`
 - No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
 
-**2. Search memory:**
+**2. Load context from prism-mcp:**
 ```
-mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+mcp__prism-mcp__session_load_context — project: REPO_SLUG, level: "standard",
+  toolAction: "Loading session context", toolSummary: "<skill-name> context recovery"
 ```
 
-**3. Assemble context:**
-```
-mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
-```
-(Use `token_budget: 1000` for `/review` and `/addressReview`.)
+Store the returned `expected_version` — you will need it at Session Close.
 
-**4. Surface results:**
-- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
-  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+**3. Surface results:**
+- If the response contains a non-empty summary or prior decisions:
+  > **Prior context:** {summary}
   Use this to inform your approach before continuing.
-- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+- If prism-mcp returns an error, surface it and stop:
+  > "prism-mcp unavailable: {error}. Ensure prism-mcp is running and registered."
+
+## Session Close
+
+> **Run at the end of every skill**, after all work is complete and the report has been shown to the user.
+
+Save a structured ledger entry and update the live handoff state for this repo.
+
+**1. Save ledger entry (immutable audit trail):**
+```
+mcp__prism-mcp__session_save_ledger — project: REPO_SLUG,
+  conversation_id: "<skill-name>-<ISO-timestamp, e.g. 2026-04-08T14:32:00Z>",
+  summary: "<one paragraph describing what was accomplished this session>",
+  todos: ["<any open items left incomplete>", ...],
+  files_changed: ["<paths of files created or modified>", ...],
+  decisions: ["<key decisions made during this skill run>", ...]
+```
+
+**2. Update handoff state (mutable live state for next session):**
+```
+mcp__prism-mcp__session_save_handoff — project: REPO_SLUG,
+  expected_version: <value returned by session_load_context>,
+  open_todos: ["<open items not yet completed>", ...],
+  active_branch: "<current git branch from: git branch --show-current>",
+  last_summary: "<one sentence: what this skill just did>",
+  key_context: "<critical facts the next session must know — constraints, decisions, blockers>"
+```
+
+If either call fails, surface the error:
+> "prism-mcp session save failed: {error}. Context may not persist to next session."
 
 <!-- === PREAMBLE END === -->
 


### PR DESCRIPTION
## Summary

- feat: integrate prism-mcp session context and dark factory into all skills

## What changed

**Session memory (all 34 skills):** Replaced bridge memory recall in `_preamble.md` with prism-mcp `session_load_context` at session start and `session_save_ledger` + `session_save_handoff` at session end. Bridge tools are retained for agent dialogue only.

**Dark Factory pipelines (5 skills):** Added unconditional adversarial PLAN → EXECUTE → EVALUATE pipelines to:
- `bugHunt` — Step 3.5: automated fix pipeline before manual steps
- `officeHours` — Step 6.5: spec validation before writing to disk
- `archReview` — Step 5.5: adversarial stress test before verdict
- `design-implement-web` — Step 3.5: token compliance audit after generation
- `design-implement-ios` — Step 3.5: Theme.swift compliance audit after SwiftUI generation

All context is scoped per `REPO_SLUG` derived from the git remote URL.

---

Shipped via `/shipRelease`.