### PR TITLE
feat: add withInterview skill

### DIFF
--- a/.claude/rules/skills.md
+++ b/.claude/rules/skills.md
@@ -44,7 +44,7 @@ Every SKILL.md embeds the shared preamble between these markers:
 When updating `skills/_preamble.md`, you **must** propagate the change to all 34 SKILL.md files that embed it. Use `Grep` to find all files: search for `=== PREAMBLE START ===`.
 
 The preamble verifies:
-1. All 34 skills are symlinked to `~/.claude/skills/`
+1. All 35 skills are symlinked to `~/.claude/skills/`
 2. The MCP bridge is built (`dist/mcp.js` exists)
 3. The `.claude/rules/` directory exists in the project root
 4. The repo-slug output directory `~/.agentic-workflow/$REPO_SLUG/` is created
@@ -109,7 +109,7 @@ When writing the bootstrap CLAUDE.md template, do not include Skills tables or K
 2. Copy the full preamble block from `skills/_preamble.md` immediately after the frontmatter `---`
 3. Write the skill's steps after the preamble
 4. Add the skill name to `setup.sh`'s `MANAGED_SKILLS` array
-5. Add a row to the skills table in `_preamble.md` and propagate to all 34 existing SKILL.md files
+5. Add a row to the skills table in `_preamble.md` and propagate to all 35 existing SKILL.md files
 6. Update the skill count in the CLAUDE.md tagline (line 3)
 
 ## Symlink Installation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — agentic-workflow
 
-> Portable Claude Code workflow toolkit: 34 custom skills, config archive, repo bootstrapper, MCP bridge for multi-agent communication, and token-efficiency tools (rtk + headroom).
+> Portable Claude Code workflow toolkit: 35 custom skills, config archive, repo bootstrapper, MCP bridge for multi-agent communication, and token-efficiency tools (rtk + headroom).
 
 Domain-specific rules are in `.claude/rules/` — they load automatically when working on matching files.
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ agentic-workflow/
 │       └── testing.md         # Test patterns, helpers, coverage policy
 ├── .serena/
 │   └── project.yml            # Serena LSP per-repo config (TypeScript)
-├── skills/                    # 34 Claude Code custom skills
+├── skills/                    # 35 Claude Code custom skills
 │   ├── review/                # Multi-agent PR review
 │   ├── postReview/            # GitHub comment publisher
 │   ├── addressReview/         # Review fix implementer

--- a/bootstrap/SKILL.md
+++ b/bootstrap/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(git *), Bash(ls *), Bash(find *), Agent, Read, Write, Glob, 
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Bash(git *), Bash(ls *), Bash(find *), Agent, Read, Write, Glob, 
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/setup.sh
+++ b/setup.sh
@@ -27,7 +27,7 @@ fi
 # Note: skills/_shared/ is intentionally excluded from MANAGED_SKILLS.
 # It is not symlinked directly — each skill accesses it via path traversal
 # from its own symlink: $(dirname "$(readlink -f "$HOME/.claude/skills/<name>/SKILL.md")")/../_shared
-MANAGED_SKILLS=(review postReview addressReview enhancePrompt rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios)
+MANAGED_SKILLS=(review postReview addressReview enhancePrompt rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios)
 
 echo "=== Agentic Workflow Setup ==="
 echo ""

--- a/skills/_preamble.md
+++ b/skills/_preamble.md
@@ -7,7 +7,7 @@
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/addressReview/SKILL.md
+++ b/skills/addressReview/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(gh *), Bash(git *), Agent, Read, Edit
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Bash(gh *), Bash(git *), Agent, Read, Edit
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/archReview/SKILL.md
+++ b/skills/archReview/SKILL.md
@@ -11,7 +11,7 @@ Reviews plans or implementations for technical soundness. Produces mandatory mer
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -29,6 +29,7 @@ Reviews plans or implementations for technical soundness. Produces mandatory mer
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -80,7 +81,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/bugHunt/SKILL.md
+++ b/skills/bugHunt/SKILL.md
@@ -11,7 +11,7 @@ Fix-and-verify loop with atomic commits, regression test generation, and tiered 
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -29,6 +29,7 @@ Fix-and-verify loop with atomic commits, regression test generation, and tiered 
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -80,7 +81,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/bugReport/SKILL.md
+++ b/skills/bugReport/SKILL.md
@@ -11,7 +11,7 @@ Read-only audit that produces a structured bug report with health scores. This s
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -29,6 +29,7 @@ Read-only audit that produces a structured bug report with health scores. This s
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -80,7 +81,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-analyze-ios/SKILL.md
+++ b/skills/design-analyze-ios/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Write, Glob, AskUserQuestion
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Read, Write, Glob, AskUserQuestion
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-analyze-web/SKILL.md
+++ b/skills/design-analyze-web/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(npx dembrandt *), Bash(git *), Read, Write, Glob, AskUserQue
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Bash(npx dembrandt *), Bash(git *), Read, Write, Glob, AskUserQue
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-analyze/SKILL.md
+++ b/skills/design-analyze/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(git *), Bash(ls *), Glob, Read, AskUserQuestion, Skill
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Bash(git *), Bash(ls *), Glob, Read, AskUserQuestion, Skill
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-evolve-ios/SKILL.md
+++ b/skills/design-evolve-ios/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Write, Edit, Glob, AskUserQuestion
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Read, Write, Edit, Glob, AskUserQuestion
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-evolve-web/SKILL.md
+++ b/skills/design-evolve-web/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(npx dembrandt *), Bash(git *), Read, Write, Edit, AskUserQue
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Bash(npx dembrandt *), Bash(git *), Read, Write, Edit, AskUserQue
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-evolve/SKILL.md
+++ b/skills/design-evolve/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(git *), Bash(ls *), Glob, Read, AskUserQuestion, Skill
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Bash(git *), Bash(ls *), Glob, Read, AskUserQuestion, Skill
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-implement-ios/SKILL.md
+++ b/skills/design-implement-ios/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Write, Edit, Glob, Bash(git *), AskUserQuestion
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -24,6 +24,7 @@ allowed-tools: Read, Write, Edit, Glob, Bash(git *), AskUserQuestion
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -75,7 +76,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-implement-web/SKILL.md
+++ b/skills/design-implement-web/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Write, Edit, Glob, Bash(git *), Bash(npx design-token-bridg
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -24,6 +24,7 @@ allowed-tools: Read, Write, Edit, Glob, Bash(git *), Bash(npx design-token-bridg
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -75,7 +76,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-implement/SKILL.md
+++ b/skills/design-implement/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(git *), Bash(ls *), Glob, Read, AskUserQuestion, Skill
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Bash(git *), Bash(ls *), Glob, Read, AskUserQuestion, Skill
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-language/SKILL.md
+++ b/skills/design-language/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(git *), Read, Write, Glob, AskUserQuestion, mcp__plugin_play
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Bash(git *), Read, Write, Glob, AskUserQuestion, mcp__plugin_play
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-mockup-ios/SKILL.md
+++ b/skills/design-mockup-ios/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(source ~/.claude/skills/*), Read, Write, Glob, AskUserQuesti
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -24,6 +24,7 @@ allowed-tools: Bash(source ~/.claude/skills/*), Read, Write, Glob, AskUserQuesti
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -75,7 +76,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-mockup-web/SKILL.md
+++ b/skills/design-mockup-web/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(*/start-server.sh *), Bash(mkdir *), Write, Read, Agent, Ask
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Bash(*/start-server.sh *), Bash(mkdir *), Write, Read, Agent, Ask
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-mockup/SKILL.md
+++ b/skills/design-mockup/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(git *), Bash(ls *), Glob, Read, AskUserQuestion, Skill
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Bash(git *), Bash(ls *), Glob, Read, AskUserQuestion, Skill
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-refine/SKILL.md
+++ b/skills/design-refine/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Read, Write, Edit, Skill, Glob, AskUserQuestion
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -26,6 +26,7 @@ allowed-tools: Read, Write, Edit, Skill, Glob, AskUserQuestion
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -77,7 +78,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-verify-ios/SKILL.md
+++ b/skills/design-verify-ios/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(source ~/.claude/skills/*), Read, Write, Glob, AskUserQuesti
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -26,6 +26,7 @@ allowed-tools: Bash(source ~/.claude/skills/*), Read, Write, Glob, AskUserQuesti
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -77,7 +78,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-verify-web/SKILL.md
+++ b/skills/design-verify-web/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Read, Write, Glob, Agent, AskUserQuestion
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -26,6 +26,7 @@ allowed-tools: Read, Write, Glob, Agent, AskUserQuestion
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -77,7 +78,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/design-verify/SKILL.md
+++ b/skills/design-verify/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(git *), Bash(ls *), Glob, Read, AskUserQuestion, Skill
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Bash(git *), Bash(ls *), Glob, Read, AskUserQuestion, Skill
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/enhancePrompt/SKILL.md
+++ b/skills/enhancePrompt/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Glob, Grep
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Read, Glob, Grep
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/officeHours/SKILL.md
+++ b/skills/officeHours/SKILL.md
@@ -11,7 +11,7 @@ Runs a structured brainstorming session and produces four domain-owned outputs â
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** â€” 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** â€” 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -29,6 +29,7 @@ Runs a structured brainstorming session and produces four domain-owned outputs â
 > | `/officeHours` | Spec-driven brainstorming â†’ product + engineering + design-brief + tasks |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -80,7 +81,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/productReview/SKILL.md
+++ b/skills/productReview/SKILL.md
@@ -11,7 +11,7 @@ Reviews plans through a product/founder lens with four distinct modes. Challenge
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -29,6 +29,7 @@ Reviews plans through a product/founder lens with four distinct modes. Challenge
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -80,7 +81,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(gh *), Bash(git *), Agent, Read, Write, Skill
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Bash(gh *), Bash(git *), Agent, Read, Write, Skill
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/rootCause/SKILL.md
+++ b/skills/rootCause/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: Bash(git *), Agent, Read, Write, Edit, Glob, Grep, Skill
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -29,6 +29,7 @@ allowed-tools: Bash(git *), Agent, Read, Write, Edit, Glob, Grep, Skill
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -80,7 +81,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/shipRelease/SKILL.md
+++ b/skills/shipRelease/SKILL.md
@@ -12,7 +12,7 @@ Syncs your branch, runs tests, audits coverage, pushes, opens a PR, and optional
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -30,6 +30,7 @@ Syncs your branch, runs tests, audits coverage, pushes, opens a PR, and optional
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -81,7 +82,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/syncDocs/SKILL.md
+++ b/skills/syncDocs/SKILL.md
@@ -12,7 +12,7 @@ Refreshes project documentation to reflect recent changes. Updates only the sect
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -30,6 +30,7 @@ Refreshes project documentation to reflect recent changes. Updates only the sect
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -81,7 +82,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/verify-app/SKILL.md
+++ b/skills/verify-app/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(git *), Bash(ls *), Glob, Read, AskUserQuestion, Skill
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Bash(git *), Bash(ls *), Glob, Read, AskUserQuestion, Skill
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/verify-ios/SKILL.md
+++ b/skills/verify-ios/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(git *), Bash(source ~/.claude/skills/*), Read, Glob, AskUser
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Bash(git *), Bash(source ~/.claude/skills/*), Read, Glob, AskUser
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/verify-web/SKILL.md
+++ b/skills/verify-web/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(git *), Agent, Read, Write, Glob, Grep, AskUserQuestion
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -25,6 +25,7 @@ allowed-tools: Bash(git *), Agent, Read, Write, Glob, Grep, AskUserQuestion
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -76,7 +77,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/weeklyRetro/SKILL.md
+++ b/skills/weeklyRetro/SKILL.md
@@ -11,7 +11,7 @@ Analyzes git history to produce per-person breakdowns, shipping streaks, test he
 
 <!-- === PREAMBLE START === -->
 
-> **Agentic Workflow** — 34 skills available. Run any as `/<name>`.
+> **Agentic Workflow** — 35 skills available. Run any as `/<name>`.
 >
 > | Skill | Purpose |
 > |-------|---------|
@@ -29,6 +29,7 @@ Analyzes git history to produce per-person breakdowns, shipping streaks, test he
 > | `/officeHours` | Spec-driven brainstorming → EARS requirements + design doc |
 > | `/productReview` | Founder/product lens plan review |
 > | `/archReview` | Engineering architecture plan review |
+> | `/withInterview` | Interview user to clarify requirements before executing |
 > | `/design-analyze` | Detect web vs iOS, extract design tokens (dispatcher) |
 > | `/design-analyze-web` | Extract design tokens from reference URLs (web) |
 > | `/design-analyze-ios` | Extract design tokens from Swift/Xcode assets |
@@ -80,7 +81,7 @@ echo "repo-slug: $REPO_SLUG"
 
 # Check bootstrap status
 SKILLS_OK=true
-for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
+for s in review postReview addressReview enhancePrompt bootstrap rootCause bugHunt bugReport shipRelease syncDocs weeklyRetro officeHours productReview archReview withInterview design-analyze design-analyze-web design-analyze-ios design-language design-evolve design-evolve-web design-evolve-ios design-mockup design-mockup-web design-mockup-ios design-implement design-implement-web design-implement-ios design-refine design-verify design-verify-web design-verify-ios verify-app verify-web verify-ios; do
   [ -d "$HOME/.claude/skills/$s" ] || SKILLS_OK=false
 done
 

--- a/skills/withInterview/SKILL.md
+++ b/skills/withInterview/SKILL.md
@@ -1,10 +1,14 @@
 ---
-name: postReview
-description: Publish a completed /review to GitHub as batched PR comments. Reads from ~/.agentic-workflow/<repo-slug>/reviews/<pr>.json and posts one review per agent (minimizing API calls). Use after /review has written a local state file and you are ready to publish.
-argument-hint: [pr-number]
-allowed-tools: Bash(gh *), Bash(git *), Read, Edit
+name: withInterview
+description: "Interview the user to clarify requirements before executing a prompt. Use when the user wants to refine a task through guided questions before implementation."
+argument-hint: "[prompt]"
+disable-model-invocation: true
+allowed-tools: Bash(git *), Bash(ls *), Agent, Read, Write, Glob, Grep, Skill
 ---
-<!-- MEMORY: SKIP -->
+
+# Interview Before Executing
+
+Runs a structured, multi-round interview to gather requirements and context before executing a task. Surfaces ambiguities, challenges assumptions, and confirms subagent strategy — then proceeds only after explicit user confirmation.
 
 <!-- === PREAMBLE START === -->
 
@@ -109,121 +113,102 @@ Create the output directory for this repo:
 mkdir -p "$HOME/.agentic-workflow/$REPO_SLUG"
 ```
 
+## Memory Recall
+
+> **Skip if** this skill is marked `<!-- MEMORY: SKIP -->`, or if `BRIDGE_OK=false`.
+
+Check for prior discussion context in memory before reading the codebase.
+
+**1. Derive a topic string** — synthesize 3-5 words from the skill argument and task intent:
+- `/officeHours add dark mode` → `"dark mode UI feature"`
+- `/rootCause TypeError cannot read properties` → `"TypeError cannot read properties"`
+- `/review 42` → use the PR title once fetched: `"PR {title} review"`
+- No argument → use the most specific descriptor available: `"{REPO_SLUG} {skill-name}"`
+
+**2. Search memory:**
+```
+mcp__agentic-bridge__search_memory — query: <topic>, repo: REPO_SLUG, mode: "hybrid", limit: 10
+```
+
+**3. Assemble context:**
+```
+mcp__agentic-bridge__get_context — query: <topic>, repo: REPO_SLUG, token_budget: 2000
+```
+
+**4. Surface results:**
+- If `get_context` returns a non-empty summary or any section with `relevance > 0.3`:
+  > **Prior context:** {summary} *(~{token_estimate} tokens)*
+  Use this to inform your approach before continuing.
+- If empty, all low-relevance, or any tool error: continue silently — do not mention the search.
+
 <!-- === PREAMBLE END === -->
 
-# Post Review to GitHub
+## The Task
 
-Reads the local review state file and publishes all findings to GitHub in batched API calls — one review submission per agent.
+$ARGUMENTS
 
-## Step 1: Resolve the PR number
+## Interview Process
 
-**If an argument was provided**, use it.
+### Round 1: Initial Analysis & High-Level Questions
 
-**If no argument**, detect from current branch:
-```bash
-gh pr list --head $(git branch --show-current) --json number,title,url
-```
+Read the task above carefully. Identify:
+- Ambiguities or underspecified requirements
+- Decisions that have more than one reasonable answer
+- Missing context that would change your approach
+- Scope boundaries that aren't clear
 
-If multiple PRs found, list and ask the user to pick.
+Present your **highest-priority questions first** — the ones whose answers will shape everything else. Group them by theme (e.g. scope, behavior, constraints, testing). Keep each question concise and offer concrete options where possible (e.g. "Should X do A or B?" rather than open-ended "What should X do?").
 
-## Step 2: Load State File
+### Round 2: Subagent Strategy
 
-Read `~/.agentic-workflow/{REPO_SLUG}/reviews/{number}.json`.
+After the user answers Round 1, ask specifically about subagent usage. Present this as a focused follow-up:
 
-If the file does not exist:
-> "No local review found for PR #{number}. Run `/review` first."
+> **Subagent Strategy:** Based on what you've described, here's how I'd recommend using subagents. Let me know what you'd prefer:
+>
+> - **Explore** — for codebase research and file discovery
+> - **Plan** — for designing an implementation strategy before coding
+> - **general-purpose** — for delegating independent subtasks in parallel
+> - **Reviewers** (e.g. Rails, TypeScript, security, performance) — for post-implementation review
+> - **None** — I'll handle everything directly
+>
+> You can pick multiple. I'll also suggest a specific combination if you'd like a recommendation.
 
-If `posted: true`:
-> "PR #{number} was already posted at {posted_at}. Post again anyway? (yes/no)"
-> Wait for confirmation before continuing.
+If the user selects **multiple subagents**, ask follow-up questions about each one:
+- What specific focus or scope should each agent have?
+- Should they run in parallel or sequentially?
+- Are there dependencies between their outputs (e.g. Explore results feeding into Plan)?
 
-## Step 3: Post Each Reviewer's Findings
+### Round 3+: Drill-Down Details
 
-For each entry in `reviewers`, post **one batched GitHub review** containing all that agent's inline comments plus a top-level summary body. This is a single API call per reviewer.
+Continue asking follow-up rounds as needed. Each round should:
+- Reference the user's previous answers ("You mentioned X — does that mean...?")
+- Go deeper on areas that are still underspecified
+- Surface edge cases and error handling questions
+- Clarify testing expectations and acceptance criteria
 
-```bash
-gh api repos/{owner}/{repo}/pulls/{number}/reviews \
-  --method POST \
-  --field commit_id="{commit_sha}" \
-  --field body="{review_body}" \
-  --field event="COMMENT" \
-  --field "comments[]={inline_comments_json}"
-```
+Keep going until you have no remaining ambiguities. Each round should be a focused set of 2-5 questions, not a wall of text.
 
-Where:
-- `{review_body}` is the reviewer's human-readable summary (see format below)
-- `{inline_comments_json}` is a JSON array of all `type: "inline"` issues for this reviewer
+### Final Round: Summarize and Confirm
 
-### Review body format
+Once all details are gathered, present a complete summary:
 
-```markdown
-## {agent} Review
-**Focus:** {focus}
+1. **Task understanding** — what you'll build, with all clarifications incorporated
+2. **Approach** — the implementation strategy step by step
+3. **Subagent plan** — which agents will be used, in what order, with what focus
+4. **Scope boundaries** — what's explicitly in and out of scope
+5. **Acceptance criteria** — how you'll know the task is done
 
-{summary}
+Ask: **"Does this look right? Any changes before I start?"**
 
-### Findings
+### Execute
 
-| Severity | File | Issue |
-|----------|------|-------|
-| blocking | `src/auth.ts` | JWT not verified before use |
-| issue | `src/api.ts` | SQL injection risk |
+Only after explicit confirmation, begin the work.
 
-{top_level_issue_bodies}
+## Rules
 
-<!-- review-data
-{
-  "agent": "{agent}",
-  "focus": "{focus}",
-  "issues": [ ... full issues array from state file ... ]
-}
--->
-```
-
-`{top_level_issue_bodies}` — append the full `body` text of any `type: "top-level"` issues directly into the review body.
-
-### Inline comment format
-
-Each `type: "inline"` issue maps to:
-```json
-{
-  "path": "src/auth.ts",
-  "position": 42,
-  "body": "**[blocking] JWT not verified**\n\nFull comment text..."
-}
-```
-
-### Capture posted comment IDs
-
-Parse the response to get the review ID and individual comment IDs:
-```bash
-RESPONSE=$(gh api repos/{owner}/{repo}/pulls/{number}/reviews \
-  --method POST ... )
-
-REVIEW_ID=$(echo $RESPONSE | jq '.id')
-```
-
-Store each returned comment ID back against the issue in the state file (`posted_comment_id`).
-
-## Step 4: Update State File
-
-After all reviews are posted, update `~/.agentic-workflow/{REPO_SLUG}/reviews/{number}.json`:
-- Set `"posted": true`
-- Set `"posted_at"` to current ISO timestamp
-- Fill in `posted_comment_id` for each issue
-
-Use the Edit tool to update the file.
-
-## Step 5: Report
-
-```
-Posted to PR #{number}: "{title}"
-
-  • security-sentinel — 3 comments (2 inline, 1 top-level)
-  • kieran-typescript-reviewer — 2 comments (2 inline)
-  • performance-oracle — 1 comment (1 top-level)
-
-Total: 6 comments · 2 API calls
-
-View: {pr_url}
-```
+- Do NOT write any code or make any changes until the interview is complete and confirmed.
+- This is a **multi-round conversation**. Do NOT try to ask everything in one message. Start broad, then drill down based on answers.
+- Each round should be focused: 2-5 questions max per round.
+- Always reference previous answers when asking follow-ups to show you're building understanding.
+- The subagent question always gets its own dedicated round.
+- If the task is trivial and truly has no ambiguity, you may collapse to fewer rounds, but still ask the subagent question and get confirmation before proceeding.


### PR DESCRIPTION
## Summary

- Adds `/withInterview` — a structured, multi-round interview skill that gathers requirements before executing a task
- Surfaces ambiguities, challenges assumptions, confirms subagent strategy, and gets explicit user sign-off before any code is written
- Skill count bumped 34 → 35 across all SKILL.md preambles, setup.sh, CLAUDE.md, README.md, and .claude/rules/skills.md

## Test plan

- [ ] Run `./setup.sh` and verify `withInterview` symlink is created at `~/.claude/skills/withInterview/`
- [ ] Invoke `/withInterview <some task>` and confirm multi-round interview flow works
- [ ] Verify all 35 SKILL.md files show consistent preamble (35 skills, withInterview in table and bootstrap check loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)